### PR TITLE
#49: Fix ODR violations in the tests

### DIFF
--- a/tests/operators_modifier/apply.cpp
+++ b/tests/operators_modifier/apply.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, apt1 == apply<func3_apply>(abc >> *qq)
@@ -9,7 +9,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, apt1 == (abc >> *qq) % apply<func3_apply>
@@ -38,9 +38,16 @@ constexpr auto apply_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void apply_anything()
+static void apply_anything()
 {
 	assert
 		, check_all_samples(apply_checker)
 		;
+}
+
+void apply_tests()
+{
+	prefix();
+	infix();
+	apply_anything();
 }

--- a/tests/operators_modifier/apply_into.cpp
+++ b/tests/operators_modifier/apply_into.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, api1 == apply_into<Class2>(abc >> spacedot)
@@ -8,7 +8,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, api1 == (abc >> spacedot) % apply_into<Class2>
@@ -36,9 +36,16 @@ constexpr auto apply_into_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void apply_into_anything()
+static void apply_into_anything()
 {
 	assert
 		, check_all_samples(apply_into_checker)
 		;
+}
+
+void apply_into_tests()
+{
+	prefix();
+	infix();
+	apply_into_anything();
 }

--- a/tests/operators_modifier/complete.cpp
+++ b/tests/operators_modifier/complete.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, com1 == complete(l1)
@@ -13,7 +13,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, com1 == l1 % complete
@@ -26,7 +26,7 @@ inline void infix()
 		;
 }
 
-inline void idempotent()
+static void idempotent()
 {
 	assert
 		, com1 == complete(com1)
@@ -68,9 +68,17 @@ constexpr auto complete_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void complete_anything()
+static void complete_anything()
 {
 	assert
 		, check_all_samples(complete_checker)
 		;
+}
+
+void complete_tests()
+{
+	prefix();
+	infix();
+	idempotent();
+	complete_anything();
 }

--- a/tests/operators_modifier/constant.cpp
+++ b/tests/operators_modifier/constant.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, con1 == constant<1>(+abc)
@@ -10,7 +10,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, con1 == +abc % constant<1>
@@ -32,9 +32,16 @@ constexpr auto constant_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void constant_anything()
+static void constant_anything()
 {
 	assert
 		, check_all_samples(constant_checker)
 		;
+}
+
+void constant_tests()
+{
+	prefix();
+	infix();
+	constant_anything();
 }

--- a/tests/operators_modifier/defaulted.cpp
+++ b/tests/operators_modifier/defaulted.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, def1 == defaulted<int>(+abc)
@@ -8,7 +8,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, def1 == +abc % defaulted<int>
@@ -28,9 +28,16 @@ constexpr auto defaulted_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void defaulted_anything()
+static void defaulted_anything()
 {
 	assert
 		, check_all_samples(defaulted_checker)
 		;
+}
+
+void defaulted_tests()
+{
+	prefix();
+	infix();
+	defaulted_anything();
 }

--- a/tests/operators_modifier/delimit.cpp
+++ b/tests/operators_modifier/delimit.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, del1 == delimit(abc, comma)
@@ -14,7 +14,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, del1 == abc % delimit(comma)
@@ -48,9 +48,16 @@ constexpr auto delimit_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void delimit_anything()
+static void delimit_anything()
 {
 	assert
 		, check_all_samples(delimit_checker)
 		;
+}
+
+void delimit_tests()
+{
+	prefix();
+	infix();
+	delimit_anything();
 }

--- a/tests/operators_modifier/delimit_keep.cpp
+++ b/tests/operators_modifier/delimit_keep.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, dek1 == delimit_keep(abc, comma)
@@ -14,7 +14,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, dek1 == abc % delimit_keep(comma)
@@ -51,9 +51,16 @@ constexpr auto delimit_keep_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void delimit_keep_anything()
+static void delimit_keep_anything()
 {
 	assert
 		, check_all_samples(delimit_keep_checker)
 		;
+}
+
+void delimit_keep_tests()
+{
+	prefix();
+	infix();
+	delimit_keep_anything();
 }

--- a/tests/operators_modifier/exactly.cpp
+++ b/tests/operators_modifier/exactly.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, exa1 == exactly<3>(l1)
@@ -10,7 +10,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, exa1 == l1 % exactly<3>
@@ -40,9 +40,16 @@ constexpr auto exactly_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void exactly_anything()
+static void exactly_anything()
 {
 	assert
 		, check_all_samples(exactly_checker)
 		;
+}
+
+void exactly_tests()
+{
+	prefix();
+	infix();
+	exactly_anything();
 }

--- a/tests/operators_modifier/fn.cpp
+++ b/tests/operators_modifier/fn.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, tra1 == fn<func1>(+abc)
@@ -11,7 +11,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, tra1 == +abc % fn<func1>
@@ -42,9 +42,16 @@ constexpr auto fn_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void fn_anything()
+static void fn_anything()
 {
 	assert
 		, check_all_samples(fn_checker)
 		;
+}
+
+void fn_tests()
+{
+	prefix();
+	infix();
+	fn_anything();
 }

--- a/tests/operators_modifier/ignore.cpp
+++ b/tests/operators_modifier/ignore.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, ign1 == ignore(abc)
@@ -11,7 +11,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, ign1 == abc % ignore
@@ -22,7 +22,7 @@ inline void infix()
 		;
 }
 
-inline void idempotent()
+static void idempotent()
 {
 	assert
 		, ign1 == ignore(ign1)
@@ -60,9 +60,17 @@ constexpr auto ignore_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void ignore_anything()
+static void ignore_anything()
 {
 	assert
 		, check_all_samples(ignore_checker)
 		;
+}
+
+void ignore_tests()
+{
+	prefix();
+	infix();
+	idempotent();
+	ignore_anything();
 }

--- a/tests/operators_modifier/into.cpp
+++ b/tests/operators_modifier/into.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, int1 == into<Class1>(spacedot)
@@ -8,7 +8,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, int1 == spacedot % into<Class1>
@@ -36,9 +36,16 @@ constexpr auto into_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void into_anything()
+static void into_anything()
 {
 	assert
 		, check_all_samples(into_checker)
 		;
+}
+
+void into_tests()
+{
+	prefix();
+	infix();
+	into_anything();
 }

--- a/tests/operators_modifier/into_choice.cpp
+++ b/tests/operators_modifier/into_choice.cpp
@@ -2,7 +2,7 @@
 
 using namespace traits::operators;
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, into_choice<Class1>(spacedot, abc) == Choice<Into<SpaceDot, Class1>, Into<ABC, Class1>>{}
@@ -12,7 +12,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	// Infix isn't ever valid with into_choice because Choice parsers must have 2 sub parsers
 
@@ -69,9 +69,16 @@ constexpr auto into_choice_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void into_choice_anything()
+static void into_choice_anything()
 {
 	assert
 		, check_all_samples(into_choice_checker)
 		;
+}
+
+void into_choice_tests()
+{
+	prefix();
+	infix();
+	into_choice_anything();
 }

--- a/tests/operators_modifier/join.cpp
+++ b/tests/operators_modifier/join.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void prefix()
+static void prefix()
 {
 	assert
 		, joi1 != join(abc)
@@ -12,7 +12,7 @@ inline void prefix()
 		;
 }
 
-inline void infix()
+static void infix()
 {
 	assert
 		, joi1 != abc % join
@@ -24,7 +24,7 @@ inline void infix()
 		;
 }
 
-inline void idempotent()
+static void idempotent()
 {
 	assert
 		, joi1 == join(joi1)
@@ -67,9 +67,17 @@ constexpr auto join_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void join_anything()
+static void join_anything()
 {
 	assert
 		, check_all_samples(join_checker)
 		;
+}
+
+void join_tests()
+{
+	prefix();
+	infix();
+	idempotent();
+	join_anything();
 }

--- a/tests/operators_modifier/multi.cpp
+++ b/tests/operators_modifier/multi.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void creation()
+static void creation()
 {
 	assert
 		, ignore % join == modifiers::multi<modifiers::ignore, modifiers::join>{}
@@ -12,7 +12,7 @@ inline void creation()
 		;
 }
 
-inline void not_commutative()
+static void not_commutative()
 {
 	assert
 		, (ignore % join) != (join % ignore)
@@ -21,7 +21,7 @@ inline void not_commutative()
 		;
 }
 
-inline void associative()
+static void associative()
 {
 	assert
 		, ((ignore % join) % complete) % into<Sink> == (ignore % (join % complete)) % into<Sink>
@@ -31,10 +31,18 @@ inline void associative()
 		;
 }
 
-inline void applying()
+static void applying()
 {
 	assert
 		, oom1 % (join % ignore % complete) == Complete<Ignore<Join<Oom1>>>{}
 		, oom1 % (join % complete % ignore) == Ignore<Complete<Join<Oom1>>>{}
 		;
+}
+
+void multi_tests()
+{
+	creation();
+	not_commutative();
+	associative();
+	applying();
 }

--- a/tests/operators_regular/basic.cpp
+++ b/tests/operators_regular/basic.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void one_literal()
+static void one_literal()
 {
 	assert
 		, "abc"_one == oc1
@@ -13,7 +13,7 @@ inline void one_literal()
 		;
 }
 
-inline void one_operator()
+static void one_operator()
 {
 	assert
 		, one<"abc"> == oc1
@@ -26,7 +26,7 @@ inline void one_operator()
 		;
 }
 
-inline void not_literal()
+static void not_literal()
 {
 	assert
 		, "abc"_not == nc1
@@ -38,7 +38,7 @@ inline void not_literal()
 		;
 }
 
-inline void not_operator()
+static void not_operator()
 {
 	assert
 		, not_<"abc"> == nc1
@@ -50,7 +50,7 @@ inline void not_operator()
 		;
 }
 
-inline void lit_literal()
+static void lit_literal()
 {
 	assert
 		, "literal"_lit == l1
@@ -63,7 +63,7 @@ inline void lit_literal()
 		;
 }
 
-inline void lit_operator()
+static void lit_operator()
 {
 	assert
 		, lit<"literal"> == l1
@@ -76,7 +76,7 @@ inline void lit_operator()
 		;
 }
 
-inline void ign_literal()
+static void ign_literal()
 {
 	assert
 		, "literal"_ign == Ignore<L1>{}
@@ -89,7 +89,7 @@ inline void ign_literal()
 		;
 }
 
-inline void ign_operator()
+static void ign_operator()
 {
 	assert
 		, ign<"literal"> == Ignore<L1>{}
@@ -102,7 +102,7 @@ inline void ign_operator()
 		;
 }
 
-inline void non_sorted_and_uniqued()
+static void non_sorted_and_uniqued()
 {
 	assert
 		, "212312323321212311"_one == OneChar<"123">{}
@@ -122,4 +122,17 @@ inline void non_sorted_and_uniqued()
 		, ""_one == OneChar<"">{}
 		, ""_not == NotChar<"">{}
 		;
+}
+
+void basic_tests()
+{
+	one_literal();
+	one_operator();
+	not_literal();
+	not_operator();
+	lit_literal();
+	lit_operator();
+	ign_literal();
+	ign_operator();
+	non_sorted_and_uniqued();
 }

--- a/tests/operators_regular/choice.cpp
+++ b/tests/operators_regular/choice.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void OneChar_and_OneChar()
+static void OneChar_and_OneChar()
 {
 	assert
 		, (oc1 | oc2) == (oc2 | oc1)
@@ -15,7 +15,7 @@ inline void OneChar_and_OneChar()
 		;
 }
 
-inline void NotChar_and_NotChar()
+static void NotChar_and_NotChar()
 {
 	assert
 		, (nc1 | nc2) == (nc2 | nc1)
@@ -30,7 +30,7 @@ inline void NotChar_and_NotChar()
 		;
 }
 
-inline void OneChar_and_NotChar()
+static void OneChar_and_NotChar()
 {
 	assert
 		, (oc1 | nc1) == (nc1 | oc1)
@@ -56,7 +56,7 @@ inline void OneChar_and_NotChar()
 
 
 
-inline void Choice_and_Choice()
+static void Choice_and_Choice()
 {
 	assert
 		, (cho1 | cho1) == cho1
@@ -78,7 +78,7 @@ inline void Choice_and_Choice()
 		;
 }
 
-inline void Choice_and_anything()
+static void Choice_and_anything()
 {
 	assert
 		, (cho1 | oc1) == Choice<L4, NC4, OC1>{}
@@ -92,7 +92,7 @@ inline void Choice_and_anything()
 		;
 }
 
-inline void void_result()
+static void void_result()
 {
 	constexpr auto void_choice = (ign1 | ign2);
 
@@ -272,11 +272,22 @@ constexpr auto choice_checker = []<Parser LHS, Parser RHS>(LHS, RHS) -> bool
 	return true;
 };
 
-inline void anything_and_anything()
+static void anything_and_anything()
 {
 	// Note that all the operations are reimplemented for choice_checker. This is intentional. That way, there's redundancy in the code.
 	// A basic implementation is here, so if/when it gets changed in the library itself, it will be detected here.
 	assert
 		, check_all_sample_pairs(choice_checker)
 		;
+}
+
+void choice_tests()
+{
+	OneChar_and_OneChar();
+	NotChar_and_NotChar();
+	OneChar_and_NotChar();
+	Choice_and_Choice();
+	Choice_and_anything();
+	void_result();
+	anything_and_anything();
 }

--- a/tests/operators_regular/maybe.cpp
+++ b/tests/operators_regular/maybe.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void Maybe_Maybe()
+static void Maybe_Maybe()
 {
 	assert
 		, ~may1 == may1
@@ -18,7 +18,7 @@ inline void Maybe_Maybe()
 		;
 }
 
-inline void Maybe_OneOrMore()
+static void Maybe_OneOrMore()
 {
 	assert
 		, ~oom1 == zom1
@@ -36,7 +36,7 @@ inline void Maybe_OneOrMore()
 		;
 }
 
-inline void Maybe_ZeroOrMore()
+static void Maybe_ZeroOrMore()
 {
 	assert
 		, ~zom1 == zom1
@@ -83,9 +83,17 @@ constexpr auto maybe_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void maybe_anything()
+static void maybe_anything()
 {
 	assert
 		, check_all_samples(maybe_checker)
 		;
+}
+
+void maybe_tests()
+{
+	Maybe_Maybe();
+	Maybe_OneOrMore();
+	Maybe_ZeroOrMore();
+	maybe_anything();
 }

--- a/tests/operators_regular/not.cpp
+++ b/tests/operators_regular/not.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void not_OneChar()
+static void not_OneChar()
 {
 	assert
 		, !oc1 == nc1
@@ -12,7 +12,7 @@ inline void not_OneChar()
 		;
 }
 
-inline void not_NotChar()
+static void not_NotChar()
 {
 	assert
 		, !nc1 == oc1
@@ -48,9 +48,16 @@ constexpr auto not_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void not_anything()
+static void not_anything()
 {
 	assert
 		, check_all_samples(not_checker)
 		;
+}
+
+void not_tests()
+{
+	not_OneChar();
+	not_NotChar();
+	not_anything();
 }

--- a/tests/operators_regular/one_or_more.cpp
+++ b/tests/operators_regular/one_or_more.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 
 
-inline void OneOrMore_Maybe()
+static void OneOrMore_Maybe()
 {
 	assert
 		, +may1 == zom1
@@ -19,7 +19,7 @@ inline void OneOrMore_Maybe()
 		;
 }
 
-inline void OneOrMore_OneOrMore()
+static void OneOrMore_OneOrMore()
 {
 	assert
 		, +oom1 == oom1
@@ -37,7 +37,7 @@ inline void OneOrMore_OneOrMore()
 		;
 }
 
-inline void OneOrMore_ZeroOrMore()
+static void OneOrMore_ZeroOrMore()
 {
 	assert
 		, +zom1 == zom1
@@ -84,9 +84,17 @@ constexpr auto one_or_more_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void one_or_more_anything()
+static void one_or_more_anything()
 {
 	assert
 		, check_all_samples(one_or_more_checker)
 		;
+}
+
+void one_or_more_tests()
+{
+	OneOrMore_Maybe();
+	OneOrMore_OneOrMore();
+	OneOrMore_ZeroOrMore();
+	one_or_more_anything();
 }

--- a/tests/operators_regular/sequence.cpp
+++ b/tests/operators_regular/sequence.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void Literal_and_Literal()
+static void Literal_and_Literal()
 {
 	assert
 		, (l1 >> l1) == Literal<"literalliteral">{}
@@ -17,7 +17,7 @@ inline void Literal_and_Literal()
 
 
 
-inline void Sequence_and_Sequence()
+static void Sequence_and_Sequence()
 {
 	assert
 		, (seq1 >> seq1) == Sequence<L4, NC4, L4, NC4>{}
@@ -39,7 +39,7 @@ inline void Sequence_and_Sequence()
 		;
 }
 
-inline void Sequence_and_anything()
+static void Sequence_and_anything()
 {
 	assert
 		, (seq1 >> oc1) == Sequence<L4, NC4, OC1>{}
@@ -53,7 +53,7 @@ inline void Sequence_and_anything()
 		;
 }
 
-inline void void_result()
+static void void_result()
 {
 	constexpr auto void_sequence = (ign1 >> ign2);
 
@@ -127,7 +127,7 @@ constexpr auto sequence_checker = []<Parser LHS, Parser RHS>(LHS, RHS) -> bool
 	return true;
 };
 
-inline void anything_and_anything()
+static void anything_and_anything()
 {
 	// Note that all the operations are reimplemented for sequence_checker. This is intentional. That way, there's redundancy in the code.
 	// A basic implementation is here, so if/when it gets changed in the library itself, it will be detected here.
@@ -136,3 +136,11 @@ inline void anything_and_anything()
 		;
 }
 
+void sequence_tests()
+{
+	Literal_and_Literal();
+	Sequence_and_Sequence();
+	Sequence_and_anything();
+	void_result();
+	anything_and_anything();
+}

--- a/tests/operators_regular/zero_or_more.cpp
+++ b/tests/operators_regular/zero_or_more.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void ZeroOrMore_Maybe()
+static void ZeroOrMore_Maybe()
 {
 	assert
 		, *may1 == zom1
@@ -18,7 +18,7 @@ inline void ZeroOrMore_Maybe()
 		;
 }
 
-inline void ZeroOrMore_OneOrMore()
+static void ZeroOrMore_OneOrMore()
 {
 	assert
 		, *oom1 == zom1
@@ -36,7 +36,7 @@ inline void ZeroOrMore_OneOrMore()
 		;
 }
 
-inline void ZeroOrMore_ZeroOrMore()
+static void ZeroOrMore_ZeroOrMore()
 {
 	assert
 		, *zom1 == zom1
@@ -83,9 +83,17 @@ constexpr auto zero_or_more_checker = []<Parser P>(P) -> bool
 	return true;
 };
 
-inline void zero_or_more_anything()
+static void zero_or_more_anything()
 {
 	assert
 		, check_all_samples(zero_or_more_checker)
 		;
+}
+
+void zero_or_more_tests()
+{
+	ZeroOrMore_Maybe();
+	ZeroOrMore_OneOrMore();
+	ZeroOrMore_ZeroOrMore();
+	zero_or_more_anything();
 }

--- a/tests/parsers_adaptor/Complete.cpp
+++ b/tests/parsers_adaptor/Complete.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Com1, CompleteType, std::string_view>
@@ -11,7 +11,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Complete_Literal()
+static void parse_Complete_Literal()
 {
 	assert
 		, parse<Com1>("litera").failure()
@@ -23,7 +23,7 @@ inline void parse_Complete_Literal()
 		, parse<Com1>("").failure()
 		;
 }
-inline void parse_Complete_OneChar()
+static void parse_Complete_OneChar()
 {
 	assert
 		, parse<Com2>("a").success({ "a" }, "")
@@ -34,7 +34,7 @@ inline void parse_Complete_OneChar()
 		, parse<Com2>("").failure()
 		;
 }
-inline void parse_Complete_Choice()
+static void parse_Complete_Choice()
 {
 	assert
 		, parse<Com3>("abliteralcbliteralcf").failure()
@@ -46,7 +46,7 @@ inline void parse_Complete_Choice()
 		, parse<Com3>("").failure()
 		;
 }
-inline void parse_Complete_Sequence()
+static void parse_Complete_Sequence()
 {
 	assert
 		, parse<Com4>("literalaliteralcliteralcliteralb").failure()
@@ -58,7 +58,7 @@ inline void parse_Complete_Sequence()
 		, parse<Com4>("").failure()
 		;
 }
-inline void parse_Complete_Maybe()
+static void parse_Complete_Maybe()
 {
 	assert
 		, parse<Com5>("literalaliteralcliteralcliteralb").failure()
@@ -70,7 +70,7 @@ inline void parse_Complete_Maybe()
 		, parse<Com5>("").success({}, "")
 		;
 }
-inline void parse_Complete_OneOrMore()
+static void parse_Complete_OneOrMore()
 {
 	assert
 		, parse<Com6>("literalaliteralcliteralcliteralb").success({ { "literal", "a" }, { "literal", "c" }, { "literal", "c" }, { "literal", "b" } }, "")
@@ -82,7 +82,7 @@ inline void parse_Complete_OneOrMore()
 		, parse<Com6>("").failure()
 		;
 }
-inline void parse_Complete_ZeroOrMore()
+static void parse_Complete_ZeroOrMore()
 {
 	assert
 		, parse<Com7>("literalaliteralcliteralcliteralb").success({ { "literal", "a" }, { "literal", "c" }, { "literal", "c" }, { "literal", "b" } }, "")
@@ -93,4 +93,16 @@ inline void parse_Complete_ZeroOrMore()
 		, parse<Com7>("aliteralaliteralcliteralbliteral").failure()
 		, parse<Com7>("").success({}, "")
 		;
+}
+
+void Complete_tests()
+{
+	requirements();
+	parse_Complete_Literal();
+	parse_Complete_OneChar();
+	parse_Complete_Choice();
+	parse_Complete_Sequence();
+	parse_Complete_Maybe();
+	parse_Complete_OneOrMore();
+	parse_Complete_ZeroOrMore();
 }

--- a/tests/parsers_adaptor/Ignore.cpp
+++ b/tests/parsers_adaptor/Ignore.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Ign1, IgnoreType, void>
@@ -11,7 +11,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Ignore()
+static void parse_Ignore()
 {
 	assert
 		, parse<Ign1>("abcabc").success("abc")
@@ -42,4 +42,10 @@ inline void parse_Ignore()
 		, parse<Ign5>(" abc").failure()
 		, parse<Ign5>("").failure()
 		;
+}
+
+void Ignore_tests()
+{
+	requirements();
+	parse_Ignore();
 }

--- a/tests/parsers_basic/Literal.cpp
+++ b/tests/parsers_basic/Literal.cpp
@@ -2,14 +2,14 @@
 
 using L = Literal<"literal">;
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<L, LiteralType, std::string_view>
 		;
 }
 
-inline void parse_single()
+static void parse_single()
 {
 	assert
 		, parse<L>("literal").success("literal", "")
@@ -25,7 +25,7 @@ inline void parse_single()
 
 using constructible = traits::basic::constructible<Literal>;
 
-inline void constructible_from_ascii_only()
+static void constructible_from_ascii_only()
 {
 	assert
 		, constructible::from<"literal">
@@ -33,11 +33,19 @@ inline void constructible_from_ascii_only()
 		;
 }
 
-inline void parse_empty()
+static void parse_empty()
 {
 	assert
 		, constructible::from<"">
 		, parse<Literal<"">>("anything").success("", "anything")
 		, parse<Literal<"">>("").success("", "")
 		;
+}
+
+void Literal_test()
+{
+	requirements();
+	parse_single();
+	constructible_from_ascii_only();
+	parse_empty();
 }

--- a/tests/parsers_basic/NotChar.cpp
+++ b/tests/parsers_basic/NotChar.cpp
@@ -3,7 +3,7 @@
 using Single = NotChar<'a'>;
 using Multi  = NotChar<"abc">;
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Single, NotCharType, std::string_view>
@@ -11,7 +11,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_single()
+static void parse_single()
 {
 	assert
 		, parse<Single>("ab").failure()
@@ -23,7 +23,7 @@ inline void parse_single()
 		;
 }
 
-inline void parse_multi()
+static void parse_multi()
 {
 	assert
 		, parse<Multi>("abc").failure()
@@ -48,7 +48,7 @@ inline void parse_multi()
 
 using constructible = traits::basic::constructible<NotChar>;
 
-inline void constructible_from_ascii_only()
+static void constructible_from_ascii_only()
 {
 	using all_ascii_chars = std::make_integer_sequence<int, 128>;
 	using all_non_ascii_chars = decltype([]<int... Is>(std::integer_sequence<int, Is...>) { return std::integer_sequence<int, (Is - 128)...>{}; }(all_ascii_chars{}));
@@ -59,7 +59,7 @@ inline void constructible_from_ascii_only()
 		;
 }
 
-inline void constructible_alphabetically_only()
+static void constructible_alphabetically_only()
 {
 	assert
 		, constructible::from<"abc">
@@ -71,11 +71,21 @@ inline void constructible_alphabetically_only()
 		;
 }
 
-inline void parse_empty()
+static void parse_empty()
 {
 	assert
 		, constructible::from<"">
 		, parse<NotChar<"">>("anything").success("a", "nything")
 		, parse<NotChar<"">>("").failure()
 		;
+}
+
+void NotChar_tests()
+{
+	requirements();
+	parse_single();
+	parse_multi();
+	constructible_from_ascii_only();
+	constructible_alphabetically_only();
+	parse_empty();
 }

--- a/tests/parsers_basic/OneChar.cpp
+++ b/tests/parsers_basic/OneChar.cpp
@@ -3,7 +3,7 @@
 using Single = OneChar<'a'>;
 using Multi  = OneChar<"abc">;
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Single, OneCharType, std::string_view>
@@ -11,7 +11,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_single()
+static void parse_single()
 {
 	assert
 		, parse<Single>("ab").success("a", "b")
@@ -23,7 +23,7 @@ inline void parse_single()
 		;
 }
 
-inline void parse_multi()
+static void parse_multi()
 {
 	assert
 		, parse<Multi>("abc").success("a", "bc")
@@ -47,7 +47,7 @@ inline void parse_multi()
 
 using constructible = traits::basic::constructible<OneChar>;
 
-inline void constructible_from_ascii_only()
+static void constructible_from_ascii_only()
 {
 	using all_ascii_chars = std::make_integer_sequence<int, 128>;
 	using all_non_ascii_chars = decltype([]<int... Is>(std::integer_sequence<int, Is...>) { return std::integer_sequence<int, (Is - 128)...>{}; }(all_ascii_chars{}));
@@ -58,7 +58,7 @@ inline void constructible_from_ascii_only()
 		;
 }
 
-inline void constructible_alphabetically_only()
+static void constructible_alphabetically_only()
 {
 	assert
 		, constructible::from<"abc">
@@ -70,11 +70,21 @@ inline void constructible_alphabetically_only()
 		;
 }
 
-inline void parse_empty()
+static void parse_empty()
 {
 	assert
 		, constructible::from<"">
 		, parse<OneChar<"">>("anything").failure()
 		, parse<OneChar<"">>("").failure()
 		;
+}
+
+void OneChar_tests()
+{
+	requirements();
+	parse_single();
+	parse_multi();
+	constructible_from_ascii_only();
+	constructible_alphabetically_only();
+	parse_empty();
 }

--- a/tests/parsers_compound/Choice.cpp
+++ b/tests/parsers_compound/Choice.cpp
@@ -6,7 +6,7 @@ using TwoWay2 = Cho2;
 using ThreeWay1 = Cho3;
 using ThreeWay2 = Cho4;
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<TwoWay1, ChoiceType, std::string_view>
@@ -16,7 +16,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_twoway()
+static void parse_twoway()
 {
 	assert
 		, parse<TwoWay1>("abc").success("ab", "c")
@@ -33,7 +33,7 @@ inline void parse_twoway()
 		;
 }
 
-inline void parse_threeway()
+static void parse_threeway()
 {
 	assert
 		, parse<ThreeWay1>("abc").success("ab", "c")
@@ -59,7 +59,7 @@ inline void parse_threeway()
 
 using constructible = traits::compound::constructible<Choice>;
 
-inline void constructible_same_result_type()
+static void constructible_same_result_type()
 {
 	assert
 		, constructible::from<OC1, OC3, NC2, NC1, L2>
@@ -67,7 +67,16 @@ inline void constructible_same_result_type()
 		;
 }
 
-inline void not_constructible_empty()
+static void not_constructible_empty()
 {
 	assert, not constructible::from<>;
+}
+
+void Choice_tests()
+{
+	requirements();
+	parse_twoway();
+	parse_threeway();
+	constructible_same_result_type();
+	not_constructible_empty();
 }

--- a/tests/parsers_compound/Sequence.cpp
+++ b/tests/parsers_compound/Sequence.cpp
@@ -3,7 +3,7 @@
 using TwoWay = Seq1;
 using ThreeWay = Seq3;
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<TwoWay, SequenceType, std::tuple<std::string_view, std::string_view>>
@@ -11,7 +11,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_twoway()
+static void parse_twoway()
 {
 	assert
 		, parse<TwoWay>("abc").failure()
@@ -21,7 +21,7 @@ inline void parse_twoway()
 		;
 }
 
-inline void parse_threeway()
+static void parse_threeway()
 {
 	assert
 		, parse<ThreeWay>("abcde").success({ "ab", "c", "d" }, "e")
@@ -34,7 +34,15 @@ inline void parse_threeway()
 
 using constructible = traits::compound::constructible<Sequence>;
 
-inline void not_constructible_empty()
+static void not_constructible_empty()
 {
 	assert, not constructible::from<>;
+}
+
+void Sequence_tests()
+{
+	requirements();
+	parse_twoway();
+	parse_threeway();
+	not_constructible_empty();
 }

--- a/tests/parsers_divergent/ApplyInto.cpp
+++ b/tests/parsers_divergent/ApplyInto.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Api1, ApplyIntoType, Class2>
@@ -8,7 +8,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_ApplyInto()
+static void parse_ApplyInto()
 {
 	assert
 		, parse<Api1>("abc.").success(Class2{ "abc", "." }, "")
@@ -21,4 +21,10 @@ inline void parse_ApplyInto()
 		, parse<Api2>(".").failure()
 		, parse<Api2>("abc").failure()
 		;
+}
+
+void ApplyInto_tests()
+{
+	requirements();
+	parse_ApplyInto();
 }

--- a/tests/parsers_divergent/ApplyTransform.cpp
+++ b/tests/parsers_divergent/ApplyTransform.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Apt1, ApplyTransformType, bool>
@@ -8,7 +8,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_ApplyTransform()
+static void parse_ApplyTransform()
 {
 	assert
 		, parse<Apt1>("abc???????").success(false, "?")
@@ -24,4 +24,10 @@ inline void parse_ApplyTransform()
 		, parse<Apt2>(" abc").failure()
 		, parse<Apt2>("").failure()
 		;
+}
+
+void ApplyTransform_tests()
+{
+	requirements();
+	parse_ApplyTransform();
 }

--- a/tests/parsers_divergent/Constant.cpp
+++ b/tests/parsers_divergent/Constant.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Con1, ConstantType, int>
@@ -10,7 +10,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Constant()
+static void parse_Constant()
 {
 	assert
 		, parse<Con1>("abcabcabcab").success(1, "ab")
@@ -37,4 +37,10 @@ inline void parse_Constant()
 		, parse<Con4>(" abc").failure()
 		, parse<Con4>("").failure()
 		;
+}
+
+void Constant_tests()
+{
+	requirements();
+	parse_Constant();
 }

--- a/tests/parsers_divergent/Custom.cpp
+++ b/tests/parsers_divergent/Custom.cpp
@@ -1,13 +1,13 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Cus1, CustomType, std::size_t>
 		;
 }
 
-inline void parse_Transform()
+static void parse_Transform()
 {
 	assert
 		, parse<Cus1>("abcabcabcabc??").success(36, "")
@@ -17,4 +17,10 @@ inline void parse_Transform()
 		, parse<Cus1>(" abc").failure()
 		, parse<Cus1>("").failure()
 		;
+}
+
+void Custom_tests()
+{
+	requirements();
+	parse_Transform();
 }

--- a/tests/parsers_divergent/Defaulted.cpp
+++ b/tests/parsers_divergent/Defaulted.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Def1, DefaultedType, int>
@@ -8,7 +8,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Join()
+static void parse_Join()
 {
 	assert
 		, parse<Def1>("abcabcabcab").success(0, "ab")
@@ -22,4 +22,10 @@ inline void parse_Join()
 		, parse<Def2>("??abcabc").success(Class3{}, "abcabc")
 		, parse<Def2>(" ??abcabc").success(Class3{}, " ??abcabc")
 		;
+}
+
+void Defaulted_tests()
+{
+	requirements();
+	parse_Join();
 }

--- a/tests/parsers_divergent/Into.cpp
+++ b/tests/parsers_divergent/Into.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Int1, IntoType, Class1>
@@ -9,7 +9,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Into()
+static void parse_Into()
 {
 	assert
 		, parse<Int1>(" ").success(Class1(0), "")
@@ -27,4 +27,10 @@ inline void parse_Into()
 		, parse<Int3>("").failure()
 		, parse<Int3>("abc").failure()
 		;
+}
+
+void Into_tests()
+{
+	requirements();
+	parse_Into();
 }

--- a/tests/parsers_divergent/Join.cpp
+++ b/tests/parsers_divergent/Join.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Joi1, JoinType, std::string_view>
@@ -11,7 +11,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Join()
+static void parse_Join()
 {
 	assert
 		, parse<Joi1>("abcabc").success("abc", "abc")
@@ -42,4 +42,10 @@ inline void parse_Join()
 		, parse<Joi5>(" abc").failure()
 		, parse<Joi5>("").failure()
 		;
+}
+
+void Join_tests()
+{
+	requirements();
+	parse_Join();
 }

--- a/tests/parsers_divergent/Transform.cpp
+++ b/tests/parsers_divergent/Transform.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Tra1, TransformType, std::size_t>
@@ -10,7 +10,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Transform()
+static void parse_Transform()
 {
 	assert
 		, parse<Tra1>("abcabcabcab").success(3, "ab")
@@ -37,4 +37,10 @@ inline void parse_Transform()
 		, parse<Tra4>(" abc").failure()
 		, parse<Tra4>("").failure()
 		;
+}
+
+void Transform_tests()
+{
+	requirements();
+	parse_Transform();
 }

--- a/tests/parsers_divergent/combine.cpp
+++ b/tests/parsers_divergent/combine.cpp
@@ -6,7 +6,7 @@ constexpr L1 l1;
 using L2 = Literal<"??">;
 constexpr L2 l2;
 
-inline void Join_Delimit()
+static void Join_Delimit()
 {
 	constexpr auto d = delimit(l1, l2);
 	constexpr auto j = d % join;
@@ -21,7 +21,7 @@ inline void Join_Delimit()
 		;
 }
 
-inline void Ignore_Sequence()
+static void Ignore_Sequence()
 {
 	constexpr auto p = l1 >> ignore(l2) >> l1;
 
@@ -31,7 +31,7 @@ inline void Ignore_Sequence()
 		;
 }
 
-inline void Join_Ignore()
+static void Join_Ignore()
 {
 	constexpr auto q = OneChar<"?">{};
 
@@ -67,7 +67,7 @@ inline void Join_Ignore()
 		;
 }
 
-inline void Join_Transform()
+static void Join_Transform()
 {
 	constexpr auto f = fn<[](auto&& v) -> std::string_view { return (v.size() % 2 == 0) ? "a" : "b"; }>;
 
@@ -96,5 +96,13 @@ inline void Join_Transform()
 		, parse(j3, "abcabc??abc??ab").only_lookahead("ab")
 		, parse(j3, "abc??abcabcabcabc??").only_lookahead("")
 		;
+}
+
+void combine_tests()
+{
+	Join_Delimit();
+	Ignore_Sequence();
+	Join_Ignore();
+	Join_Transform();
 }
 #endif

--- a/tests/parsers_repeat/Delimit.cpp
+++ b/tests/parsers_repeat/Delimit.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Del1, DelimitType, std::vector<std::string_view>>
@@ -14,7 +14,7 @@ inline void requirements()
 		;
 }
 
-inline void requirements_keep()
+static void requirements_keep()
 {
 	assert
 		, IsParser<Dek1, DelimitType, std::pair<std::vector<std::string_view>, std::vector<std::string_view>>>
@@ -28,7 +28,7 @@ inline void requirements_keep()
 		;
 }
 
-inline void parse_Delimit_regular()
+static void parse_Delimit_regular()
 {
 	assert
 		, parse<Del1>("abc,abc,abc,,abc,abc,abc").success({ "abc", "abc", "abc" }, ",,abc,abc,abc")
@@ -52,7 +52,7 @@ inline void parse_Delimit_regular()
 		;
 }
 
-inline void parse_Delimit_reversed()
+static void parse_Delimit_reversed()
 {
 	assert
 		, parse<Del5>("abc,abc,abc,,abc,abc,abc").failure()
@@ -76,7 +76,7 @@ inline void parse_Delimit_reversed()
 		;
 }
 
-inline void parse_Delimit_keep_regular()
+static void parse_Delimit_keep_regular()
 {
 	assert
 		, parse<Dek1>("abc,abc,abc,,abc,abc,abc").success({ { "abc", "abc", "abc" }, { ",", "," } }, ",,abc,abc,abc")
@@ -100,7 +100,7 @@ inline void parse_Delimit_keep_regular()
 		;
 }
 
-inline void parse_Delimit_keep_reversed()
+static void parse_Delimit_keep_reversed()
 {
 	assert
 		, parse<Dek5>("abc,abc,abc,,abc,abc,abc").failure()
@@ -122,4 +122,14 @@ inline void parse_Delimit_keep_reversed()
 		, parse<Dek8>(" ?? ??.?? .??.?? ??").success({ { " ", " ", ".", " " }, { "??", "??", "??" } }, ".??.?? ??")
 		, parse<Dek8>("").failure()
 		;
+}
+
+void Delimit_tests()
+{
+	requirements();
+	requirements_keep();
+	parse_Delimit_regular();
+	parse_Delimit_reversed();
+	parse_Delimit_keep_regular();
+	parse_Delimit_keep_reversed();
 }

--- a/tests/parsers_repeat/Exactly.cpp
+++ b/tests/parsers_repeat/Exactly.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Exa1, ExactlyType, std::array<std::string_view, 3>>
@@ -10,7 +10,7 @@ inline void requirements()
 		;
 }
 
-inline void constructibility()
+static void constructibility()
 {
 	using traits::repeat::Exactly::constructible;
 	assert
@@ -20,7 +20,7 @@ inline void constructibility()
 		;
 }
 
-inline void parse_Exactly_Literal()
+static void parse_Exactly_Literal()
 {
 	assert
 		, parse<Exa1>("litera").failure()
@@ -33,7 +33,7 @@ inline void parse_Exactly_Literal()
 		, parse<Exa1>("").failure()
 		;
 }
-inline void parse_Exactly_OneChar()
+static void parse_Exactly_OneChar()
 {
 	assert
 		, parse<Exa2>("abcbaa").success({ "a", "b", "c", "b", "a" }, "a")
@@ -42,7 +42,7 @@ inline void parse_Exactly_OneChar()
 		, parse<Exa2>("").failure()
 		;
 }
-inline void parse_Exactly_Choice()
+static void parse_Exactly_Choice()
 {
 	assert
 		, parse<Exa3>("abliteralcbliteralcf").success({ "a", "b", "literal", "c" }, "bliteralcf")
@@ -51,7 +51,7 @@ inline void parse_Exactly_Choice()
 		, parse<Exa3>("").failure()
 		;
 }
-inline void parse_Exactly_Sequence()
+static void parse_Exactly_Sequence()
 {
 	assert
 		, parse<Exa4>("literalaliteralcliteralcliteralb").success({{ {"literal", "a"}, {"literal", "c"} }}, "literalcliteralb")
@@ -59,4 +59,14 @@ inline void parse_Exactly_Sequence()
 		, parse<Exa4>("aliteralaliteralcliteralbliteral").failure()
 		, parse<Exa4>("").failure()
 		;
+}
+
+void Exactly_tests()
+{
+	requirements();
+	constructibility();
+	parse_Exactly_Literal();
+	parse_Exactly_OneChar();
+	parse_Exactly_Choice();
+	parse_Exactly_Sequence();
 }

--- a/tests/parsers_repeat/Maybe.cpp
+++ b/tests/parsers_repeat/Maybe.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<May1, MaybeType, std::optional<std::string_view>>
@@ -10,7 +10,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_Maybe_Literal()
+static void parse_Maybe_Literal()
 {
 	assert
 		, parse<May1>("litera").success({}, "litera")
@@ -22,7 +22,7 @@ inline void parse_Maybe_Literal()
 		, parse<May1>("").success({}, "")
 		;
 }
-inline void parse_Maybe_OneChar()
+static void parse_Maybe_OneChar()
 {
 	assert
 		, parse<May2>("abcdef").success({ "a" }, "bcdef")
@@ -31,7 +31,7 @@ inline void parse_Maybe_OneChar()
 		, parse<May2>("").success({}, "")
 		;
 }
-inline void parse_Maybe_Choice()
+static void parse_Maybe_Choice()
 {
 	assert
 		, parse<May3>("abliteralcbliteralcf").success({ "a" }, "bliteralcbliteralcf")
@@ -40,7 +40,7 @@ inline void parse_Maybe_Choice()
 		, parse<May3>("").success({}, "")
 		;
 }
-inline void parse_Maybe_Sequence()
+static void parse_Maybe_Sequence()
 {
 	assert
 		, parse<May4>("literalaliteralcliteralcliteralb").success({ {"literal", "a"} }, "literalcliteralcliteralb")
@@ -48,4 +48,13 @@ inline void parse_Maybe_Sequence()
 		, parse<May4>("aliteralaliteralcliteralbliteral").success({}, "aliteralaliteralcliteralbliteral")
 		, parse<May4>("").success({}, "")
 		;
+}
+
+void Maybe_tests()
+{
+	requirements();
+	parse_Maybe_Literal();
+	parse_Maybe_OneChar();
+	parse_Maybe_Choice();
+	parse_Maybe_Sequence();
 }

--- a/tests/parsers_repeat/OneOrMore.cpp
+++ b/tests/parsers_repeat/OneOrMore.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Oom1, OneOrMoreType, std::vector<std::string_view>>
@@ -10,7 +10,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_OneOrMore_Literal()
+static void parse_OneOrMore_Literal()
 {
 	assert
 		, parse<Oom1>("litera").failure()
@@ -22,7 +22,7 @@ inline void parse_OneOrMore_Literal()
 		, parse<Oom1>("").failure()
 		;
 }
-inline void parse_OneOrMore_OneChar()
+static void parse_OneOrMore_OneChar()
 {
 	assert
 		, parse<Oom2>("abcdef").success({ "a", "b", "c" }, "def")
@@ -31,7 +31,7 @@ inline void parse_OneOrMore_OneChar()
 		, parse<Oom2>("").failure()
 		;
 }
-inline void parse_OneOrMore_Choice()
+static void parse_OneOrMore_Choice()
 {
 	assert
 		, parse<Oom3>("abliteralcbliteralcf").success({ "a", "b", "literal", "c", "b", "literal", "c" }, "f")
@@ -40,7 +40,7 @@ inline void parse_OneOrMore_Choice()
 		, parse<Oom3>("").failure()
 		;
 }
-inline void parse_OneOrMore_Sequence()
+static void parse_OneOrMore_Sequence()
 {
 	assert
 		, parse<Oom4>("literalaliteralcliteralcliteralb").success({ {"literal", "a"}, {"literal", "c"}, {"literal", "c"}, {"literal", "b"} }, "")
@@ -48,4 +48,13 @@ inline void parse_OneOrMore_Sequence()
 		, parse<Oom4>("aliteralaliteralcliteralbliteral").failure()
 		, parse<Oom4>("").failure()
 		;
+}
+
+void OneOrMore_tests()
+{
+	requirements();
+	parse_OneOrMore_Literal();
+	parse_OneOrMore_OneChar();
+	parse_OneOrMore_Choice();
+	parse_OneOrMore_Sequence();
 }

--- a/tests/parsers_repeat/ZeroOrMore.cpp
+++ b/tests/parsers_repeat/ZeroOrMore.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-inline void requirements()
+static void requirements()
 {
 	assert
 		, IsParser<Zom1, ZeroOrMoreType, std::vector<std::string_view>>
@@ -10,7 +10,7 @@ inline void requirements()
 		;
 }
 
-inline void parse_ZeroOrMore_Literal()
+static void parse_ZeroOrMore_Literal()
 {
 	assert
 		, parse<Zom1>("litera").success({}, "litera")
@@ -22,7 +22,7 @@ inline void parse_ZeroOrMore_Literal()
 		, parse<Zom1>("").success({}, "")
 		;
 }
-inline void parse_ZeroOrMore_OneChar()
+static void parse_ZeroOrMore_OneChar()
 {
 	assert
 		, parse<Zom2>("abcdef").success({ "a", "b", "c" }, "def")
@@ -31,7 +31,7 @@ inline void parse_ZeroOrMore_OneChar()
 		, parse<Zom2>("").success({}, "")
 		;
 }
-inline void parse_ZeroOrMore_Choice()
+static void parse_ZeroOrMore_Choice()
 {
 	assert
 		, parse<Zom3>("abliteralcbliteralcf").success({ "a", "b", "literal", "c", "b", "literal", "c" }, "f")
@@ -40,7 +40,7 @@ inline void parse_ZeroOrMore_Choice()
 		, parse<Zom3>("").success({}, "")
 		;
 }
-inline void parse_ZeroOrMore_Sequence()
+static void parse_ZeroOrMore_Sequence()
 {
 	assert
 		, parse<Zom4>("literalaliteralcliteralcliteralb").success({ {"literal", "a"}, {"literal", "c"}, {"literal", "c"}, {"literal", "b"} }, "")
@@ -48,4 +48,13 @@ inline void parse_ZeroOrMore_Sequence()
 		, parse<Zom4>("aliteralaliteralcliteralbliteral").success({}, "aliteralaliteralcliteralbliteral")
 		, parse<Zom4>("").success({}, "")
 		;
+}
+
+void ZeroOrMore_tests()
+{
+	requirements();
+	parse_ZeroOrMore_Literal();
+	parse_ZeroOrMore_OneChar();
+	parse_ZeroOrMore_Choice();
+	parse_ZeroOrMore_Sequence();
 }


### PR DESCRIPTION
Each file was given a new void function at the bottom, named `{filename}_tests()`, that calls all other files. Now, the static linkage functions are fine, and won't cause compiler warnings.