### PR TITLE
#8: Allow move-only and copy-only result types

### DIFF
--- a/include/k3/tok3n/concepts/IsResult.h
+++ b/include/k3/tok3n/concepts/IsResult.h
@@ -19,7 +19,7 @@ namespace IsResult::Void
 
 	template <class R, class T>
 	concept Constructible =
-		std::constructible_from<R>                    and
+		std::constructible_from<R>                     and
 		std::constructible_from<R, FailureTag, Input>  and
 		std::constructible_from<R, SuccessTag, Input>;
 

--- a/include/k3/tok3n/concepts/IsResult.h
+++ b/include/k3/tok3n/concepts/IsResult.h
@@ -48,10 +48,10 @@ namespace IsResult::NonVoid
 
 	template <class R, class T>
 	concept Constructible =
-		std::constructible_from<R>                               and
-		std::constructible_from<R, FailureTag, Input>            and
-		std::constructible_from<R, SuccessTag, T&&, Input>       and
-		std::constructible_from<R, SuccessTag, const T&, Input>;
+		std::constructible_from<R>                                     and
+		std::constructible_from<R, FailureTag, Input>                  and
+			(std::constructible_from<R, SuccessTag, T&&, Input> or
+			 std::constructible_from<R, SuccessTag, const T&, Input>);
 
 }
 

--- a/include/k3/tok3n/types/Result.h
+++ b/include/k3/tok3n/types/Result.h
@@ -15,7 +15,10 @@ public:
 	constexpr Result(FailureTag, Input remaining)
 		: mResult(), mRemaining(remaining) {}
 
-	constexpr Result(SuccessTag, T t, Input remaining)
+	constexpr Result(SuccessTag, const T& t, Input remaining) requires std::constructible_from<T, const T&>
+		: mResult(t), mRemaining(remaining) {}
+
+	constexpr Result(SuccessTag, T&& t, Input remaining) requires std::constructible_from<T, T&&>
 		: mResult(std::move(t)), mRemaining(remaining) {}
 
 	constexpr explicit operator bool() const noexcept { return mResult.operator bool(); }

--- a/tests/asserts/Concept.h
+++ b/tests/asserts/Concept.h
@@ -3,8 +3,12 @@
 #include <k3/tok3n/concepts/Parser.h>
 
 #define ASSERT_CONCEPT(Concept, ...)                                             \
-	ASSERT(Concept<__VA_ARGS__>,                                                 \
+	ASSERT((Concept<__VA_ARGS__>),                                               \
 		"`" STR(__VA_ARGS__) "` does not satisfy the " STR(Concept) " concept.")
+
+#define ASSERT_NOT_CONCEPT(Concept, ...)                                                  \
+	ASSERT(not (Concept<__VA_ARGS__>),                                                    \
+		"`" STR(__VA_ARGS__) "` satisfies the " STR(Concept) " concept, but should not.")
 
 #define ASSERT_IS_PARSER(P, PARSER_TYPE, ...)                                                  \
 	ASSERT_CONCEPT(Parser, P);                                                                 \

--- a/tests/parsers_compound/Choice.cpp
+++ b/tests/parsers_compound/Choice.cpp
@@ -71,3 +71,27 @@ TEST("Choice", "Not constructible empty")
 {
 	ASSERT_PARSER_NOT_CONSTRUCTIBLE(Choice);
 }
+
+
+
+TEST("Choice", "Move only")
+{
+	using T = MoveOnlyWrapper<std::string_view>;
+	using P = Choice<Into<OC3, T>, Into<ABC, T>>;
+
+	ASSERT_PARSE_SUCCESS(P, "xyz", T("x"), "yz");
+	ASSERT_PARSE_FAILURE(P, "abxyz");
+	ASSERT_PARSE_SUCCESS(P, "abcxyz", T("abc"), "xyz");
+	ASSERT_PARSE_SUCCESS(P, "zabcxyz", T("z"), "abcxyz");
+}
+
+TEST("Choice", "Copy only")
+{
+	using T = CopyOnlyWrapper<std::string_view>;
+	using P = Choice<Into<OC3, T>, Into<ABC, T>>;
+
+	ASSERT_PARSE_SUCCESS(P, "xyz", T("x"), "yz");
+	ASSERT_PARSE_FAILURE(P, "abxyz");
+	ASSERT_PARSE_SUCCESS(P, "abcxyz", T("abc"), "xyz");
+	ASSERT_PARSE_SUCCESS(P, "zabcxyz", T("z"), "abcxyz");
+}

--- a/tests/parsers_divergent/ApplyInto.cpp
+++ b/tests/parsers_divergent/ApplyInto.cpp
@@ -20,3 +20,25 @@ TEST("ApplyInto", "Parse all")
 	ASSERT_PARSE_FAILURE(Api2, ".");
 	ASSERT_PARSE_FAILURE(Api2, "abc");
 }
+
+TEST("ApplyInto", "Move only")
+{
+	using tuple = std::tuple<std::string_view, std::string_view>;
+	using T = MoveOnlyWrapper<tuple>;
+	using P = ApplyInto<Sequence<OC3, ABC>, T>;
+
+	ASSERT_PARSE_SUCCESS(P, "xabcd", T(std::tuple("x", "abc")), "d");
+	ASSERT_PARSE_FAILURE(P, "ydcba");
+	ASSERT_PARSE_SUCCESS(P, "zabcabcd", T(std::tuple("z", "abc")), "abcd");
+}
+
+TEST("ApplyInto", "Copy only")
+{
+	using tuple = std::tuple<std::string_view, std::string_view>;
+	using T = CopyOnlyWrapper<tuple>;
+	using P = ApplyInto<Sequence<OC3, ABC>, T>;
+
+	ASSERT_PARSE_SUCCESS(P, "xabcd", T(std::tuple("x", "abc")), "d");
+	ASSERT_PARSE_FAILURE(P, "ydcba");
+	ASSERT_PARSE_SUCCESS(P, "zabcabcd", T(std::tuple("z", "abc")), "abcd");
+}

--- a/tests/parsers_divergent/ApplyTransform.cpp
+++ b/tests/parsers_divergent/ApplyTransform.cpp
@@ -23,3 +23,25 @@ TEST("ApplyTransform", "Parse all")
 	ASSERT_PARSE_FAILURE(Apt2, " abc");
 	ASSERT_PARSE_FAILURE(Apt2, "");
 }
+
+TEST("ApplyTransform", "Move only")
+{
+	using tuple = std::tuple<std::string_view, std::string_view>;
+	using T = MoveOnlyWrapper<tuple>;
+	using P = ApplyTransform<Sequence<OC3, ABC>, Const<T::make>>;
+
+	ASSERT_PARSE_SUCCESS(P, "xabcd", T(std::tuple("x", "abc")), "d");
+	ASSERT_PARSE_FAILURE(P, "ydcba");
+	ASSERT_PARSE_SUCCESS(P, "zabcabcd", T(std::tuple("z", "abc")), "abcd");
+}
+
+TEST("ApplyTransform", "Copy only")
+{
+	using tuple = std::tuple<std::string_view, std::string_view>;
+	using T = CopyOnlyWrapper<tuple>;
+	using P = ApplyTransform<Sequence<OC3, ABC>, Const<T::make>>;
+
+	ASSERT_PARSE_SUCCESS(P, "xabcd", T(std::tuple("x", "abc")), "d");
+	ASSERT_PARSE_FAILURE(P, "ydcba");
+	ASSERT_PARSE_SUCCESS(P, "zabcabcd", T(std::tuple("z", "abc")), "abcd");
+}

--- a/tests/parsers_divergent/Into.cpp
+++ b/tests/parsers_divergent/Into.cpp
@@ -26,3 +26,23 @@ TEST("Into", "Parse all")
 	ASSERT_PARSE_FAILURE(Int3, "");
 	ASSERT_PARSE_FAILURE(Int3, "abc");
 }
+
+TEST("Into", "Move only")
+{
+	using T = MoveOnlyWrapper<std::string_view>;
+	using P = Into<ABC, T>;
+
+	ASSERT_PARSE_SUCCESS(P, "abcd", T("abc"), "d");
+	ASSERT_PARSE_FAILURE(P, "dcba");
+	ASSERT_PARSE_SUCCESS(P, "abcabcd", T("abc"), "abcd");
+}
+
+TEST("Into", "Copy only")
+{
+	using T = CopyOnlyWrapper<std::string_view>;
+	using P = Into<ABC, T>;
+
+	ASSERT_PARSE_SUCCESS(P, "abcd", T("abc"), "d");
+	ASSERT_PARSE_FAILURE(P, "dcba");
+	ASSERT_PARSE_SUCCESS(P, "abcabcd", T("abc"), "abcd");
+}

--- a/tests/parsers_divergent/Transform.cpp
+++ b/tests/parsers_divergent/Transform.cpp
@@ -36,3 +36,23 @@ TEST("Transform", "Parse all")
 	ASSERT_PARSE_FAILURE(Tra4, " abc");
 	ASSERT_PARSE_FAILURE(Tra4, "");
 }
+
+TEST("Transform", "Move only")
+{
+	using T = MoveOnlyWrapper<std::string_view>;
+	using P = Transform<ABC, Const<T::make>>;
+
+	ASSERT_PARSE_SUCCESS(P, "abcd", T("abc"), "d");
+	ASSERT_PARSE_FAILURE(P, "dcba");
+	ASSERT_PARSE_SUCCESS(P, "abcabcd", T("abc"), "abcd");
+}
+
+TEST("Transform", "Copy only")
+{
+	using T = CopyOnlyWrapper<std::string_view>;
+	using P = Transform<ABC, Const<T::make>>;
+
+	ASSERT_PARSE_SUCCESS(P, "abcd", T("abc"), "d");
+	ASSERT_PARSE_FAILURE(P, "dcba");
+	ASSERT_PARSE_SUCCESS(P, "abcabcd", T("abc"), "abcd");
+}

--- a/tests/pch.h
+++ b/tests/pch.h
@@ -22,6 +22,7 @@
 #include "samples/divergent.h"
 #include "samples/functions.h"
 #include "samples/repeat.h"
+#include "samples/wrappers.h"
 
 #include <format>
 #include <map>

--- a/tests/samples/wrappers.h
+++ b/tests/samples/wrappers.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <type_traits>
+
+template <class T>
+class MoveOnlyWrapper
+{
+public:
+	template <class... Args>
+	constexpr MoveOnlyWrapper(Args&&... args)
+		: _value(std::forward<Args>(args)...)
+	{}
+
+	static constexpr auto make = []<class... Args>(Args&&... args) -> MoveOnlyWrapper
+	{
+		return MoveOnlyWrapper(std::forward<Args>(args)...);
+	};
+
+	MoveOnlyWrapper(const MoveOnlyWrapper&) = delete;
+	MoveOnlyWrapper& operator=(const MoveOnlyWrapper&) = delete;
+
+	MoveOnlyWrapper(MoveOnlyWrapper&&) = default;
+	MoveOnlyWrapper& operator=(MoveOnlyWrapper&&) = default;
+	~MoveOnlyWrapper() = default;
+
+	constexpr T& value() { return _value; }
+	constexpr const T& value() const { return _value; }
+
+private:
+	T _value;
+};

--- a/tests/samples/wrappers.h
+++ b/tests/samples/wrappers.h
@@ -28,3 +28,31 @@ public:
 private:
 	T _value;
 };
+
+template <class T>
+class CopyOnlyWrapper
+{
+public:
+	template <class... Args>
+	constexpr CopyOnlyWrapper(Args&&... args)
+		: _value(std::forward<Args>(args)...)
+	{}
+
+	static constexpr auto make = []<class... Args>(Args&&... args) -> CopyOnlyWrapper
+	{
+		return CopyOnlyWrapper(std::forward<Args>(args)...);
+	};
+
+	CopyOnlyWrapper(const CopyOnlyWrapper&) = default;
+	CopyOnlyWrapper& operator=(const CopyOnlyWrapper&) = default;
+
+	CopyOnlyWrapper(CopyOnlyWrapper&&) = delete;
+	CopyOnlyWrapper& operator=(CopyOnlyWrapper&&) = delete;
+	~CopyOnlyWrapper() = default;
+
+	constexpr T& value() { return _value; }
+	constexpr const T& value() const { return _value; }
+
+private:
+	T _value;
+};

--- a/tests/samples/wrappers.h
+++ b/tests/samples/wrappers.h
@@ -25,6 +25,8 @@ public:
 	constexpr T& value() { return _value; }
 	constexpr const T& value() const { return _value; }
 
+	friend constexpr bool operator==(const MoveOnlyWrapper&, const MoveOnlyWrapper&) = default;
+
 private:
 	T _value;
 };
@@ -52,6 +54,8 @@ public:
 
 	constexpr T& value() { return _value; }
 	constexpr const T& value() const { return _value; }
+
+	friend constexpr bool operator==(const CopyOnlyWrapper&, const CopyOnlyWrapper&) = default;
 
 private:
 	T _value;

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="framework\Runner.cpp" />
     <ClCompile Include="framework\Test.cpp" />
     <ClCompile Include="framework\TestResult.cpp" />
+    <ClCompile Include="utility_tests\Result.cpp" />
     <ClCompile Include="parsers_optimizations\JoinContiguous.cpp" />
     <ClCompile Include="operators_modifier\multi.cpp" />
     <ClCompile Include="operators_modifier\delimit_keep.cpp" />

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -193,6 +193,7 @@
     <ClInclude Include="samples\sub_parsers.h" />
     <ClInclude Include="framework\underlying.h" />
     <ClInclude Include="framework\StringBuilder.h" />
+    <ClInclude Include="samples\wrappers.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="framework\Fixture.cpp" />

--- a/tests/tests.vcxproj.filters
+++ b/tests/tests.vcxproj.filters
@@ -20,6 +20,9 @@
     <Filter Include="parsers_optimizations">
       <UniqueIdentifier>{41975ec8-355f-4ac5-ad99-52a84c5925be}</UniqueIdentifier>
     </Filter>
+    <Filter Include="utility_tests">
+      <UniqueIdentifier>{cceee427-5b28-41ac-8ba5-5dceed8809b6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -229,6 +232,9 @@
     </ClCompile>
     <ClCompile Include="parsers_optimizations\JoinContiguous.cpp">
       <Filter>parsers_optimizations</Filter>
+    </ClCompile>
+    <ClCompile Include="utility_tests\Result.cpp">
+      <Filter>utility_tests</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/tests.vcxproj.filters
+++ b/tests/tests.vcxproj.filters
@@ -89,6 +89,9 @@
     <ClInclude Include="framework\StringBuilder.h">
       <Filter>framework</Filter>
     </ClInclude>
+    <ClInclude Include="samples\wrappers.h">
+      <Filter>samples</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/tests/utility_tests/Result.cpp
+++ b/tests/utility_tests/Result.cpp
@@ -1,0 +1,105 @@
+#include "pch.h"
+
+FIXTURE("Result");
+
+TEST("Result", "IsResult Result<void>")
+{
+	using R = Result<void>;
+
+	ASSERT_CONCEPT    (IsResult, R, void);
+	ASSERT_NOT_CONCEPT(IsResult, R, int);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+}
+
+TEST("Result", "IsResult Result<int>")
+{
+	using R = Result<int>;
+
+	ASSERT_NOT_CONCEPT(IsResult, R, void);
+	ASSERT_CONCEPT    (IsResult, R, int);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, double);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+}
+
+TEST("Result", "IsResult Result<std::pair>")
+{
+	using R = Result<std::pair<int, double>>;
+
+	ASSERT_NOT_CONCEPT(IsResult, R, void);
+	ASSERT_NOT_CONCEPT(IsResult, R, int);
+	ASSERT_CONCEPT    (IsResult, R, std::pair<int, double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, double);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+}
+
+TEST("Result", "IsResult Result<std::string>")
+{
+	using R = Result<std::string>;
+
+	ASSERT_NOT_CONCEPT(IsResult, R, void);
+	ASSERT_NOT_CONCEPT(IsResult, R, int);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>);
+	ASSERT_CONCEPT    (IsResult, R, std::string);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, double);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+}
+
+TEST("Result", "IsResult Result<std::vector>")
+{
+	using R = Result<std::vector<int>>;
+
+	ASSERT_NOT_CONCEPT(IsResult, R, void);
+	ASSERT_NOT_CONCEPT(IsResult, R, int);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
+	ASSERT_CONCEPT    (IsResult, R, std::vector<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, double);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+}
+
+TEST("Result", "IsResult Result<std::unique_ptr>")
+{
+	using R = Result<std::unique_ptr<int>>;
+
+	ASSERT_NOT_CONCEPT(IsResult, R, void);
+	ASSERT_NOT_CONCEPT(IsResult, R, int);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
+	ASSERT_CONCEPT    (IsResult, R, std::unique_ptr<int>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, double);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+}

--- a/tests/utility_tests/Result.cpp
+++ b/tests/utility_tests/Result.cpp
@@ -36,6 +36,11 @@ TEST("Result", "IsResult Result<int>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, int&);
+	ASSERT_NOT_CONCEPT(IsResult, R, int&&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const int&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const int&&);
 }
 
 TEST("Result", "IsResult Result<std::pair>")
@@ -58,6 +63,11 @@ TEST("Result", "IsResult Result<std::pair>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>&&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::pair<int, double>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::pair<int, double>&&);
 }
 
 TEST("Result", "IsResult Result<std::string>")
@@ -80,6 +90,11 @@ TEST("Result", "IsResult Result<std::string>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string&);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string&&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::string&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::string&&);
 }
 
 TEST("Result", "IsResult Result<std::vector>")
@@ -102,6 +117,11 @@ TEST("Result", "IsResult Result<std::vector>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>&&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::vector<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::vector<int>&&);
 }
 
 TEST("Result", "IsResult Result<std::unique_ptr>")
@@ -124,6 +144,11 @@ TEST("Result", "IsResult Result<std::unique_ptr>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>&&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::unique_ptr<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const std::unique_ptr<int>&&);
 }
 
 TEST("Result", "IsResult Result<MoveOnlyWrapper>")
@@ -146,6 +171,11 @@ TEST("Result", "IsResult Result<MoveOnlyWrapper>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>&&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const MoveOnlyWrapper<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const MoveOnlyWrapper<int>&&);
 }
 
 TEST("Result", "IsResult Result<CopyOnlyWrapper>")
@@ -168,4 +198,9 @@ TEST("Result", "IsResult Result<CopyOnlyWrapper>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>&&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const CopyOnlyWrapper<int>&);
+	ASSERT_NOT_CONCEPT(IsResult, R, const CopyOnlyWrapper<int>&&);
 }

--- a/tests/utility_tests/Result.cpp
+++ b/tests/utility_tests/Result.cpp
@@ -13,6 +13,7 @@ TEST("Result", "IsResult Result<void>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>);
 }
 
 TEST("Result", "IsResult Result<int>")
@@ -26,6 +27,7 @@ TEST("Result", "IsResult Result<int>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
@@ -33,6 +35,7 @@ TEST("Result", "IsResult Result<int>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::pair>")
@@ -46,6 +49,7 @@ TEST("Result", "IsResult Result<std::pair>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
@@ -53,6 +57,7 @@ TEST("Result", "IsResult Result<std::pair>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::string>")
@@ -66,6 +71,7 @@ TEST("Result", "IsResult Result<std::string>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
@@ -73,6 +79,7 @@ TEST("Result", "IsResult Result<std::string>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::vector>")
@@ -86,6 +93,7 @@ TEST("Result", "IsResult Result<std::vector>")
 	ASSERT_CONCEPT    (IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
@@ -93,6 +101,7 @@ TEST("Result", "IsResult Result<std::vector>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::unique_ptr>")
@@ -106,6 +115,7 @@ TEST("Result", "IsResult Result<std::unique_ptr>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_CONCEPT    (IsResult, R, std::unique_ptr<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
@@ -113,6 +123,7 @@ TEST("Result", "IsResult Result<std::unique_ptr>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<MoveOnlyWrapper>")
@@ -126,6 +137,7 @@ TEST("Result", "IsResult Result<MoveOnlyWrapper>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
 	ASSERT_CONCEPT    (IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
@@ -133,4 +145,27 @@ TEST("Result", "IsResult Result<MoveOnlyWrapper>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
+}
+
+TEST("Result", "IsResult Result<CopyOnlyWrapper>")
+{
+	using R = Result<CopyOnlyWrapper<int>>;
+
+	ASSERT_NOT_CONCEPT(IsResult, R, void);
+	ASSERT_NOT_CONCEPT(IsResult, R, int);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
+	ASSERT_CONCEPT    (IsResult, R, CopyOnlyWrapper<int>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, double);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, CopyOnlyWrapper<double>);
 }

--- a/tests/utility_tests/Result.cpp
+++ b/tests/utility_tests/Result.cpp
@@ -12,6 +12,7 @@ TEST("Result", "IsResult Result<void>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
 }
 
 TEST("Result", "IsResult Result<int>")
@@ -24,12 +25,14 @@ TEST("Result", "IsResult Result<int>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::pair>")
@@ -42,12 +45,14 @@ TEST("Result", "IsResult Result<std::pair>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::string>")
@@ -60,12 +65,14 @@ TEST("Result", "IsResult Result<std::string>")
 	ASSERT_CONCEPT    (IsResult, R, std::string);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::vector>")
@@ -78,12 +85,14 @@ TEST("Result", "IsResult Result<std::vector>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
 	ASSERT_CONCEPT    (IsResult, R, std::vector<int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 }
 
 TEST("Result", "IsResult Result<std::unique_ptr>")
@@ -96,10 +105,32 @@ TEST("Result", "IsResult Result<std::unique_ptr>")
 	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
 	ASSERT_CONCEPT    (IsResult, R, std::unique_ptr<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<int>);
 
 	ASSERT_NOT_CONCEPT(IsResult, R, double);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
 	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
+}
+
+TEST("Result", "IsResult Result<MoveOnlyWrapper>")
+{
+	using R = Result<MoveOnlyWrapper<int>>;
+
+	ASSERT_NOT_CONCEPT(IsResult, R, void);
+	ASSERT_NOT_CONCEPT(IsResult, R, int);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<int, double>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::string);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<int>);
+	ASSERT_CONCEPT    (IsResult, R, MoveOnlyWrapper<int>);
+
+	ASSERT_NOT_CONCEPT(IsResult, R, double);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::pair<double, int>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::wstring);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::vector<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, std::unique_ptr<long>);
+	ASSERT_NOT_CONCEPT(IsResult, R, MoveOnlyWrapper<double>);
 }


### PR DESCRIPTION
Also add testing to ensure they keep working properly.