### PR TITLE
#101: Turn `Input` into `Input<T>` and `Result<T>` into `Result<T, U>`

### DIFF
--- a/include/k3/tok3n/concepts/IsResult.h
+++ b/include/k3/tok3n/concepts/IsResult.h
@@ -14,14 +14,14 @@ namespace IsResult::Void
 		{
 			{ static_cast<R>(r).operator bool() } -> std::same_as<bool>;
 			{ static_cast<R>(r).has_value() } -> std::same_as<bool>;
-			{ static_cast<R>(r).remaining() } -> std::same_as<Input>;
+			{ static_cast<R>(r).remaining() } -> std::same_as<Input<char>>;
 		};
 
 	template <class R>
 	concept Constructible =
-		std::constructible_from<R>                     and
-		std::constructible_from<R, FailureTag, Input>  and
-		std::constructible_from<R, SuccessTag, Input>;
+		std::constructible_from<R>                           and
+		std::constructible_from<R, FailureTag, Input<char>>  and
+		std::constructible_from<R, SuccessTag, Input<char>>;
 
 }
 
@@ -48,10 +48,10 @@ namespace IsResult::NonVoid
 
 	template <class R, class T>
 	concept Constructible =
-		std::constructible_from<R>                                     and
-		std::constructible_from<R, FailureTag, Input>                  and
-			(std::constructible_from<R, SuccessTag, T&&, Input> or
-			 std::constructible_from<R, SuccessTag, const T&, Input>);
+		std::constructible_from<R>                                           and
+		std::constructible_from<R, FailureTag, Input<char>>                  and
+			(std::constructible_from<R, SuccessTag, T&&, Input<char>> or
+			 std::constructible_from<R, SuccessTag, const T&, Input<char>>);
 
 }
 

--- a/include/k3/tok3n/concepts/Parser.h
+++ b/include/k3/tok3n/concepts/Parser.h
@@ -15,7 +15,7 @@ concept Parser =
 	(std::is_empty_v<P>) &&
 	detail::implicitly_default_constructible<P> &&
 	requires { typename P::result_type; } &&
-	requires (Input input)
+	requires (Input<char> input)
 	{
 		{ P::parse(input) } -> IsResult<typename P::result_type>;
 		{ P::lookahead(input) } -> IsResult<void>;

--- a/include/k3/tok3n/parsers/adaptor/Complete.h
+++ b/include/k3/tok3n/parsers/adaptor/Complete.h
@@ -11,7 +11,7 @@ struct Complete
 
 	static constexpr ParserType type = CompleteType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (not result.has_value() or result.remaining() != "")
@@ -20,7 +20,7 @@ struct Complete
 			return result;
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		auto result = P::lookahead(input);
 		if (not result.has_value() or result.remaining() != "")

--- a/include/k3/tok3n/parsers/adaptor/Complete.h
+++ b/include/k3/tok3n/parsers/adaptor/Complete.h
@@ -11,7 +11,7 @@ struct Complete
 
 	static constexpr ParserType type = CompleteType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (not result.has_value() or result.remaining() != "")
@@ -20,7 +20,7 @@ struct Complete
 			return result;
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		auto result = P::lookahead(input);
 		if (not result.has_value() or result.remaining() != "")

--- a/include/k3/tok3n/parsers/adaptor/Ignore.h
+++ b/include/k3/tok3n/parsers/adaptor/Ignore.h
@@ -11,12 +11,12 @@ struct Ignore
 
 	static constexpr ParserType type = IgnoreType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		return P::lookahead(input);
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/adaptor/Ignore.h
+++ b/include/k3/tok3n/parsers/adaptor/Ignore.h
@@ -11,12 +11,12 @@ struct Ignore
 
 	static constexpr ParserType type = IgnoreType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		return P::lookahead(input);
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/basic/BasicBase.h
+++ b/include/k3/tok3n/parsers/basic/BasicBase.h
@@ -7,7 +7,7 @@ template <class P>
 struct BasicTraits
 {
 	// static constexpr std::size_t length;
-	// static constexpr bool failure_condition(Input);
+	// static constexpr bool failure_condition(Input<char>);
 };
 
 template <class P>
@@ -15,7 +15,7 @@ struct BasicBase
 {
 	using result_type = Output;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<P>;
 
@@ -25,7 +25,7 @@ struct BasicBase
 			return { success, { input.data(), Traits::length }, { input.data() + Traits::length, input.size() - Traits::length } };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<P>;
 

--- a/include/k3/tok3n/parsers/basic/BasicBase.h
+++ b/include/k3/tok3n/parsers/basic/BasicBase.h
@@ -15,7 +15,7 @@ struct BasicBase
 {
 	using result_type = Output;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<P>;
 
@@ -25,7 +25,7 @@ struct BasicBase
 			return { success, { input.data(), Traits::length }, { input.data() + Traits::length, input.size() - Traits::length } };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<P>;
 

--- a/include/k3/tok3n/parsers/basic/Literal.h
+++ b/include/k3/tok3n/parsers/basic/Literal.h
@@ -9,7 +9,7 @@ struct BasicTraits<Literal<str>>
 {
 	static constexpr std::size_t length = str.size();
 
-	static constexpr bool failure_condition(Input input)
+	static constexpr bool failure_condition(Input<char> input)
 	{
 		return (input.size() < length) || (Input(str.span()) != input.first(length));
 	}

--- a/include/k3/tok3n/parsers/basic/NotChar.h
+++ b/include/k3/tok3n/parsers/basic/NotChar.h
@@ -10,7 +10,7 @@ struct BasicTraits<NotChar<str>>
 {
 	static constexpr std::size_t length = 1;
 
-	static constexpr bool failure_condition(Input input)
+	static constexpr bool failure_condition(Input<char> input)
 	{
 		return input.empty() || str.contains(input.front());
 	}

--- a/include/k3/tok3n/parsers/basic/OneChar.h
+++ b/include/k3/tok3n/parsers/basic/OneChar.h
@@ -10,7 +10,7 @@ struct BasicTraits<OneChar<str>>
 {
 	static constexpr std::size_t length = 1;
 
-	static constexpr bool failure_condition(Input input)
+	static constexpr bool failure_condition(Input<char> input)
 	{
 		return input.empty() || not str.contains(input.front());
 	}

--- a/include/k3/tok3n/parsers/compound/Choice.h
+++ b/include/k3/tok3n/parsers/compound/Choice.h
@@ -10,7 +10,7 @@ namespace detail::executors
 	template <class ResultType>
 	struct Choice
 	{
-		Input input;
+		Input<char> input;
 		Result<ResultType>& result;
 
 		template <Parser P>
@@ -34,7 +34,7 @@ struct Choice
 
 	static constexpr ParserType type = ChoiceType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		Result<result_type> result;
 
@@ -45,7 +45,7 @@ struct Choice
 		return result;
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		Result<void> result;
 

--- a/include/k3/tok3n/parsers/compound/Choice.h
+++ b/include/k3/tok3n/parsers/compound/Choice.h
@@ -11,7 +11,7 @@ namespace detail::executors
 	struct Choice
 	{
 		Input<char> input;
-		Result<ResultType>& result;
+		Result<ResultType, char>& result;
 
 		template <Parser P>
 		constexpr bool execute()
@@ -34,9 +34,9 @@ struct Choice
 
 	static constexpr ParserType type = ChoiceType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
-		Result<result_type> result;
+		Result<result_type, char> result;
 
 		using Executor = detail::executors::Choice<result_type>;
 		Executor executor{ input, result };
@@ -45,9 +45,9 @@ struct Choice
 		return result;
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
-		Result<void> result;
+		Result<void, char> result;
 
 		using Executor = detail::executors::Choice<void>;
 		Executor executor{ input, result };

--- a/include/k3/tok3n/parsers/compound/Sequence.h
+++ b/include/k3/tok3n/parsers/compound/Sequence.h
@@ -68,7 +68,7 @@ struct Sequence
 	using result_type                = _trait::type;
 	static constexpr bool _unwrapped = _trait::unwrapped;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		// This might be a problem because it default initializes all members
 		using Executor = detail::executors::Sequence<result_type>;
@@ -88,7 +88,7 @@ struct Sequence
 			return { success, std::move(executor.full_result), executor.input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		using Executor = detail::executors::Sequence<void>;
 		Executor executor{ .input = input };

--- a/include/k3/tok3n/parsers/compound/Sequence.h
+++ b/include/k3/tok3n/parsers/compound/Sequence.h
@@ -17,7 +17,7 @@ namespace detail::executors
 	{
 		using StoredResult = std::conditional_t<std::same_as<ResultType, void>, VoidResultTag, ResultType>;
 
-		Input input;
+		Input<char> input;
 		StoredResult full_result = {};
 
 		template <Parser P, std::size_t I, bool unwrapped>
@@ -68,7 +68,7 @@ struct Sequence
 	using result_type                = _trait::type;
 	static constexpr bool _unwrapped = _trait::unwrapped;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		// This might be a problem because it default initializes all members
 		using Executor = detail::executors::Sequence<result_type>;
@@ -88,7 +88,7 @@ struct Sequence
 			return { success, std::move(executor.full_result), executor.input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		using Executor = detail::executors::Sequence<void>;
 		Executor executor{ .input = input };

--- a/include/k3/tok3n/parsers/divergent/ApplyInto.h
+++ b/include/k3/tok3n/parsers/divergent/ApplyInto.h
@@ -11,7 +11,7 @@ struct ApplyInto
 
 	static constexpr ParserType type = ApplyIntoType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct ApplyInto
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/ApplyInto.h
+++ b/include/k3/tok3n/parsers/divergent/ApplyInto.h
@@ -11,16 +11,16 @@ struct ApplyInto
 
 	static constexpr ParserType type = ApplyIntoType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
-			return { success, std::make_from_tuple<result_type>(std::move(*result)), result.remaining()};
+			return { success, std::make_from_tuple<result_type>(std::move(*result)), result.remaining() };
 		else
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/ApplyTransform.h
+++ b/include/k3/tok3n/parsers/divergent/ApplyTransform.h
@@ -11,7 +11,7 @@ struct ApplyTransform
 
 	static constexpr ParserType type = ApplyTransformType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct ApplyTransform
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/ApplyTransform.h
+++ b/include/k3/tok3n/parsers/divergent/ApplyTransform.h
@@ -11,7 +11,7 @@ struct ApplyTransform
 
 	static constexpr ParserType type = ApplyTransformType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct ApplyTransform
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Constant.h
+++ b/include/k3/tok3n/parsers/divergent/Constant.h
@@ -10,7 +10,7 @@ struct Constant
 
 	static constexpr ParserType type = ConstantType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -19,7 +19,7 @@ struct Constant
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Constant.h
+++ b/include/k3/tok3n/parsers/divergent/Constant.h
@@ -10,7 +10,7 @@ struct Constant
 
 	static constexpr ParserType type = ConstantType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -19,7 +19,7 @@ struct Constant
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Custom.h
+++ b/include/k3/tok3n/parsers/divergent/Custom.h
@@ -9,14 +9,14 @@ struct Custom
 	static constexpr ParserType type = CustomType;
 
 	template <std::same_as<CRTP> P = CRTP>
-	static constexpr Result<typename P::result_type> parse(Input input)
+	static constexpr Result<typename P::result_type> parse(Input<char> input)
 	{
 		static_assert(requires { { P::get_parser() } -> Parser; });
 		return decltype(P::get_parser())::parse(input);
 	}
 
 	template <std::same_as<CRTP> P = CRTP>
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		static_assert(requires { { P::get_parser() } -> Parser; });
 		return decltype(P::get_parser())::lookahead(input);

--- a/include/k3/tok3n/parsers/divergent/Custom.h
+++ b/include/k3/tok3n/parsers/divergent/Custom.h
@@ -9,14 +9,14 @@ struct Custom
 	static constexpr ParserType type = CustomType;
 
 	template <std::same_as<CRTP> P = CRTP>
-	static constexpr Result<typename P::result_type> parse(Input<char> input)
+	static constexpr Result<typename P::result_type, char> parse(Input<char> input)
 	{
 		static_assert(requires { { P::get_parser() } -> Parser; });
 		return decltype(P::get_parser())::parse(input);
 	}
 
 	template <std::same_as<CRTP> P = CRTP>
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		static_assert(requires { { P::get_parser() } -> Parser; });
 		return decltype(P::get_parser())::lookahead(input);

--- a/include/k3/tok3n/parsers/divergent/Defaulted.h
+++ b/include/k3/tok3n/parsers/divergent/Defaulted.h
@@ -11,7 +11,7 @@ struct Defaulted
 
 	static constexpr ParserType type = DefaultedType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct Defaulted
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Defaulted.h
+++ b/include/k3/tok3n/parsers/divergent/Defaulted.h
@@ -11,7 +11,7 @@ struct Defaulted
 
 	static constexpr ParserType type = DefaultedType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct Defaulted
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Into.h
+++ b/include/k3/tok3n/parsers/divergent/Into.h
@@ -11,7 +11,7 @@ struct Into
 
 	static constexpr ParserType type = IntoType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct Into
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Into.h
+++ b/include/k3/tok3n/parsers/divergent/Into.h
@@ -11,16 +11,16 @@ struct Into
 
 	static constexpr ParserType type = IntoType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
-			return { success, result_type(std::move(*result)), result.remaining()};
+			return { success, result_type(std::move(*result)), result.remaining() };
 		else
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Join.h
+++ b/include/k3/tok3n/parsers/divergent/Join.h
@@ -10,7 +10,7 @@ namespace detail::executors
 	{
 	public:
 		template <class T>
-		constexpr Join(const Result<T>& t)
+		constexpr Join(const Result<T, char>& t)
 		{
 			if (this->try_join(*t) && joined == std::nullopt)
 			{
@@ -97,7 +97,7 @@ struct Join
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -110,7 +110,7 @@ struct Join
 		return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Join.h
+++ b/include/k3/tok3n/parsers/divergent/Join.h
@@ -97,7 +97,7 @@ struct Join
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -110,7 +110,7 @@ struct Join
 		return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Transform.h
+++ b/include/k3/tok3n/parsers/divergent/Transform.h
@@ -11,7 +11,7 @@ struct Transform
 
 	static constexpr ParserType type = TransformType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct Transform
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/divergent/Transform.h
+++ b/include/k3/tok3n/parsers/divergent/Transform.h
@@ -11,7 +11,7 @@ struct Transform
 
 	static constexpr ParserType type = TransformType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct Transform
 			return { failure, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		return P::lookahead(input);
 	}

--- a/include/k3/tok3n/parsers/optimizations/JoinExactlyBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinExactlyBasic.h
@@ -12,7 +12,7 @@ struct Join<Exactly<Basic<str>, N>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -30,7 +30,7 @@ struct Join<Exactly<Basic<str>, N>>
 		return { success, result, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/optimizations/JoinExactlyBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinExactlyBasic.h
@@ -12,7 +12,7 @@ struct Join<Exactly<Basic<str>, N>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -30,7 +30,7 @@ struct Join<Exactly<Basic<str>, N>>
 		return { success, result, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/optimizations/JoinMaybeBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinMaybeBasic.h
@@ -12,7 +12,7 @@ struct Join<Maybe<Basic<str>>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -22,7 +22,7 @@ struct Join<Maybe<Basic<str>>>
 		return { success, { input.data(), Traits::length }, { input.data() + Traits::length, input.size() - Traits::length } };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/optimizations/JoinMaybeBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinMaybeBasic.h
@@ -12,7 +12,7 @@ struct Join<Maybe<Basic<str>>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -22,7 +22,7 @@ struct Join<Maybe<Basic<str>>>
 		return { success, { input.data(), Traits::length }, { input.data() + Traits::length, input.size() - Traits::length } };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/optimizations/JoinOneOrMoreBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinOneOrMoreBasic.h
@@ -12,7 +12,7 @@ struct Join<OneOrMore<Basic<str>>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -31,7 +31,7 @@ struct Join<OneOrMore<Basic<str>>>
 		return { success, result, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/optimizations/JoinOneOrMoreBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinOneOrMoreBasic.h
@@ -12,7 +12,7 @@ struct Join<OneOrMore<Basic<str>>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -31,7 +31,7 @@ struct Join<OneOrMore<Basic<str>>>
 		return { success, result, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/optimizations/JoinZeroOrMoreBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinZeroOrMoreBasic.h
@@ -12,7 +12,7 @@ struct Join<ZeroOrMore<Basic<str>>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -27,7 +27,7 @@ struct Join<ZeroOrMore<Basic<str>>>
 		return { success, result, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/optimizations/JoinZeroOrMoreBasic.h
+++ b/include/k3/tok3n/parsers/optimizations/JoinZeroOrMoreBasic.h
@@ -12,7 +12,7 @@ struct Join<ZeroOrMore<Basic<str>>>
 
 	static constexpr ParserType type = JoinType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 
@@ -27,7 +27,7 @@ struct Join<ZeroOrMore<Basic<str>>>
 		return { success, result, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		using Traits = BasicTraits<Basic<str>>;
 

--- a/include/k3/tok3n/parsers/repeat/Delimit.h
+++ b/include/k3/tok3n/parsers/repeat/Delimit.h
@@ -14,7 +14,7 @@ struct Delimit
 
 	static constexpr ParserType type = DelimitType;
 
-	static constexpr Result<result_type> parse(Input<char> input) requires (not KeepDelimiters::value)
+	static constexpr Result<result_type, char> parse(Input<char> input) requires (not KeepDelimiters::value)
 	{
 		result_type results;
 
@@ -37,7 +37,7 @@ struct Delimit
 		return { success, std::move(results), input };
 	}
 
-	static constexpr Result<result_type> parse(Input<char> input) requires (KeepDelimiters::value)
+	static constexpr Result<result_type, char> parse(Input<char> input) requires (KeepDelimiters::value)
 	{
 		result_type results;
 		auto& [values, delimiters] = results;
@@ -63,7 +63,7 @@ struct Delimit
 		return { success, std::move(results), input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		auto result = P::lookahead(input);
 		if (not result.has_value())

--- a/include/k3/tok3n/parsers/repeat/Delimit.h
+++ b/include/k3/tok3n/parsers/repeat/Delimit.h
@@ -14,7 +14,7 @@ struct Delimit
 
 	static constexpr ParserType type = DelimitType;
 
-	static constexpr Result<result_type> parse(Input input) requires (not KeepDelimiters::value)
+	static constexpr Result<result_type> parse(Input<char> input) requires (not KeepDelimiters::value)
 	{
 		result_type results;
 
@@ -37,7 +37,7 @@ struct Delimit
 		return { success, std::move(results), input };
 	}
 
-	static constexpr Result<result_type> parse(Input input) requires (KeepDelimiters::value)
+	static constexpr Result<result_type> parse(Input<char> input) requires (KeepDelimiters::value)
 	{
 		result_type results;
 		auto& [values, delimiters] = results;
@@ -63,7 +63,7 @@ struct Delimit
 		return { success, std::move(results), input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		auto result = P::lookahead(input);
 		if (not result.has_value())

--- a/include/k3/tok3n/parsers/repeat/Exactly.h
+++ b/include/k3/tok3n/parsers/repeat/Exactly.h
@@ -11,7 +11,7 @@ struct Exactly
 
 	static constexpr ParserType type = ExactlyType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		const Input original_input = input;
 		result_type results;
@@ -31,7 +31,7 @@ struct Exactly
 		return { success, std::move(results), input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		const Input original_input = input;
 

--- a/include/k3/tok3n/parsers/repeat/Exactly.h
+++ b/include/k3/tok3n/parsers/repeat/Exactly.h
@@ -11,7 +11,7 @@ struct Exactly
 
 	static constexpr ParserType type = ExactlyType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		const Input original_input = input;
 		result_type results;
@@ -31,7 +31,7 @@ struct Exactly
 		return { success, std::move(results), input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		const Input original_input = input;
 

--- a/include/k3/tok3n/parsers/repeat/Maybe.h
+++ b/include/k3/tok3n/parsers/repeat/Maybe.h
@@ -11,7 +11,7 @@ struct Maybe
 
 	static constexpr ParserType type = MaybeType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct Maybe
 			return { success, result_type{ std::nullopt }, input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
 		auto result = P::lookahead(input);
 		if (result.has_value())

--- a/include/k3/tok3n/parsers/repeat/Maybe.h
+++ b/include/k3/tok3n/parsers/repeat/Maybe.h
@@ -11,7 +11,7 @@ struct Maybe
 
 	static constexpr ParserType type = MaybeType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		auto result = P::parse(input);
 		if (result.has_value())
@@ -20,7 +20,7 @@ struct Maybe
 			return { success, result_type{ std::nullopt }, input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		auto result = P::lookahead(input);
 		if (result.has_value())

--- a/include/k3/tok3n/parsers/repeat/OneOrMore.h
+++ b/include/k3/tok3n/parsers/repeat/OneOrMore.h
@@ -11,7 +11,7 @@ struct OneOrMore
 
 	static constexpr ParserType type = OneOrMoreType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		const Input original_input = input;
 		result_type results;
@@ -34,9 +34,9 @@ struct OneOrMore
 			return { failure, original_input };
 	}
 
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
-		Result<void> result;
+		Result<void, char> result;
 		bool successful = false;
 		
 		do

--- a/include/k3/tok3n/parsers/repeat/OneOrMore.h
+++ b/include/k3/tok3n/parsers/repeat/OneOrMore.h
@@ -11,7 +11,7 @@ struct OneOrMore
 
 	static constexpr ParserType type = OneOrMoreType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		const Input original_input = input;
 		result_type results;
@@ -34,7 +34,7 @@ struct OneOrMore
 			return { failure, original_input };
 	}
 
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		Result<void> result;
 		bool successful = false;

--- a/include/k3/tok3n/parsers/repeat/ZeroOrMore.h
+++ b/include/k3/tok3n/parsers/repeat/ZeroOrMore.h
@@ -11,7 +11,7 @@ struct ZeroOrMore
 
 	static constexpr ParserType type = ZeroOrMoreType;
 
-	static constexpr Result<result_type> parse(Input<char> input)
+	static constexpr Result<result_type, char> parse(Input<char> input)
 	{
 		const Input original_input = input;
 		result_type results;
@@ -31,9 +31,9 @@ struct ZeroOrMore
 		return { success, std::move(results), input };
 	}
 	
-	static constexpr Result<void> lookahead(Input<char> input)
+	static constexpr Result<void, char> lookahead(Input<char> input)
 	{
-		Result<void> result;
+		Result<void, char> result;
 
 		do
 		{

--- a/include/k3/tok3n/parsers/repeat/ZeroOrMore.h
+++ b/include/k3/tok3n/parsers/repeat/ZeroOrMore.h
@@ -11,7 +11,7 @@ struct ZeroOrMore
 
 	static constexpr ParserType type = ZeroOrMoreType;
 
-	static constexpr Result<result_type> parse(Input input)
+	static constexpr Result<result_type> parse(Input<char> input)
 	{
 		const Input original_input = input;
 		result_type results;
@@ -31,7 +31,7 @@ struct ZeroOrMore
 		return { success, std::move(results), input };
 	}
 	
-	static constexpr Result<void> lookahead(Input input)
+	static constexpr Result<void> lookahead(Input<char> input)
 	{
 		Result<void> result;
 

--- a/include/k3/tok3n/types/Input.h
+++ b/include/k3/tok3n/types/Input.h
@@ -5,12 +5,13 @@
 
 namespace k3::tok3n {
 
+template <class T>
 class Input
 {
 public:
 	constexpr Input() = default;
 
-	constexpr Input(std::span<const char> value)
+	constexpr Input(std::span<const T> value)
 		: _value(value)
 	{}
 
@@ -19,18 +20,18 @@ public:
 	{}
 
 	template <std::size_t N>
-	constexpr Input(const char(&arr)[N])
+	constexpr Input(const char(&arr)[N]) requires std::same_as<T, char>
 		: _value(arr, N - 1)
 	{}
 
-	constexpr Input(const char* data, std::size_t size)
+	constexpr Input(const T* data, std::size_t size)
 		: _value(data, size)
 	{}
 
-	constexpr const char* data() const { return _value.data(); }
+	constexpr const T* data() const { return _value.data(); }
 	constexpr std::size_t size() const { return _value.size(); }
 	constexpr bool empty() const { return _value.empty(); }
-	constexpr const char& front() const { return _value.front(); }
+	constexpr const T& front() const { return _value.front(); }
 
 	constexpr Input first(std::size_t count) const { return { _value.first(count) }; }
 	constexpr Input subspan(std::size_t offset, std::size_t count = std::dynamic_extent) const { return { _value.subspan(offset, count) }; }
@@ -41,7 +42,7 @@ public:
 	}
 
 private:
-	std::span<const char> _value;
+	std::span<const T> _value;
 };
 
 } // namespace k3::tok3n

--- a/include/k3/tok3n/types/Result.h
+++ b/include/k3/tok3n/types/Result.h
@@ -5,20 +5,20 @@
 
 namespace k3::tok3n {
 
-template <class T>
+template <class T, class U>
 requires (not std::is_reference_v<T>)
 class Result
 {
 public:
 	constexpr Result() = default;
 
-	constexpr Result(FailureTag, Input<char> remaining)
+	constexpr Result(FailureTag, Input<U> remaining)
 		: mResult(), mRemaining(remaining) {}
 
-	constexpr Result(SuccessTag, const T& t, Input<char> remaining) requires std::constructible_from<T, const T&>
+	constexpr Result(SuccessTag, const T& t, Input<U> remaining) requires std::constructible_from<T, const T&>
 		: mResult(t), mRemaining(remaining) {}
 
-	constexpr Result(SuccessTag, T&& t, Input<char> remaining) requires std::constructible_from<T, T&&>
+	constexpr Result(SuccessTag, T&& t, Input<U> remaining) requires std::constructible_from<T, T&&>
 		: mResult(std::move(t)), mRemaining(remaining) {}
 
 	constexpr explicit operator bool() const noexcept { return mResult.operator bool(); }
@@ -34,33 +34,33 @@ public:
 	constexpr T&&       operator*() &&      { return *std::move(mResult); }
 	constexpr const T&& operator*() const&& { return *std::move(mResult); }
 
-	constexpr Input<char> remaining() const noexcept { return mRemaining; }
+	constexpr Input<U> remaining() const noexcept { return mRemaining; }
 
 private:
 	std::optional<T> mResult;
-	Input<char> mRemaining;
+	Input<U> mRemaining;
 };
 
-template <>
-class Result<void>
+template <class U>
+class Result<void, U>
 {
 public:
 	constexpr Result() = default;
 
-	constexpr Result(FailureTag, Input<char> remaining)
+	constexpr Result(FailureTag, Input<U> remaining)
 		: mSuccessful(false), mRemaining(remaining) {}
 
-	constexpr Result(SuccessTag, Input<char> remaining)
+	constexpr Result(SuccessTag, Input<U> remaining)
 		: mSuccessful(true), mRemaining(remaining) {}
 
 	constexpr explicit operator bool() const noexcept { return mSuccessful; }
 	constexpr bool has_value() const noexcept         { return mSuccessful; }
 
-	constexpr Input<char> remaining() const noexcept { return mRemaining; }
+	constexpr Input<U> remaining() const noexcept { return mRemaining; }
 
 private:
 	bool mSuccessful;
-	Input<char> mRemaining;
+	Input<U> mRemaining;
 };
 
 } // namespace k3::tok3n

--- a/include/k3/tok3n/types/Result.h
+++ b/include/k3/tok3n/types/Result.h
@@ -12,13 +12,13 @@ class Result
 public:
 	constexpr Result() = default;
 
-	constexpr Result(FailureTag, Input remaining)
+	constexpr Result(FailureTag, Input<char> remaining)
 		: mResult(), mRemaining(remaining) {}
 
-	constexpr Result(SuccessTag, const T& t, Input remaining) requires std::constructible_from<T, const T&>
+	constexpr Result(SuccessTag, const T& t, Input<char> remaining) requires std::constructible_from<T, const T&>
 		: mResult(t), mRemaining(remaining) {}
 
-	constexpr Result(SuccessTag, T&& t, Input remaining) requires std::constructible_from<T, T&&>
+	constexpr Result(SuccessTag, T&& t, Input<char> remaining) requires std::constructible_from<T, T&&>
 		: mResult(std::move(t)), mRemaining(remaining) {}
 
 	constexpr explicit operator bool() const noexcept { return mResult.operator bool(); }
@@ -34,11 +34,11 @@ public:
 	constexpr T&&       operator*() &&      { return *std::move(mResult); }
 	constexpr const T&& operator*() const&& { return *std::move(mResult); }
 
-	constexpr Input remaining() const noexcept { return mRemaining; }
+	constexpr Input<char> remaining() const noexcept { return mRemaining; }
 
 private:
 	std::optional<T> mResult;
-	Input mRemaining;
+	Input<char> mRemaining;
 };
 
 template <>
@@ -47,20 +47,20 @@ class Result<void>
 public:
 	constexpr Result() = default;
 
-	constexpr Result(FailureTag, Input remaining)
+	constexpr Result(FailureTag, Input<char> remaining)
 		: mSuccessful(false), mRemaining(remaining) {}
 
-	constexpr Result(SuccessTag, Input remaining)
+	constexpr Result(SuccessTag, Input<char> remaining)
 		: mSuccessful(true), mRemaining(remaining) {}
 
 	constexpr explicit operator bool() const noexcept { return mSuccessful; }
 	constexpr bool has_value() const noexcept         { return mSuccessful; }
 
-	constexpr Input remaining() const noexcept { return mRemaining; }
+	constexpr Input<char> remaining() const noexcept { return mRemaining; }
 
 private:
 	bool mSuccessful;
-	Input mRemaining;
+	Input<char> mRemaining;
 };
 
 } // namespace k3::tok3n

--- a/tests/utility_tests/Result.cpp
+++ b/tests/utility_tests/Result.cpp
@@ -4,7 +4,7 @@ FIXTURE("Result");
 
 TEST("Result", "IsResult Result<void>")
 {
-	using R = Result<void>;
+	using R = Result<void, char>;
 
 	ASSERT_CONCEPT    (IsResult, R, void);
 	ASSERT_NOT_CONCEPT(IsResult, R, int);
@@ -18,7 +18,7 @@ TEST("Result", "IsResult Result<void>")
 
 TEST("Result", "IsResult Result<int>")
 {
-	using R = Result<int>;
+	using R = Result<int, char>;
 
 	ASSERT_NOT_CONCEPT(IsResult, R, void);
 	ASSERT_CONCEPT    (IsResult, R, int);
@@ -45,7 +45,7 @@ TEST("Result", "IsResult Result<int>")
 
 TEST("Result", "IsResult Result<std::pair>")
 {
-	using R = Result<std::pair<int, double>>;
+	using R = Result<std::pair<int, double>, char>;
 
 	ASSERT_NOT_CONCEPT(IsResult, R, void);
 	ASSERT_NOT_CONCEPT(IsResult, R, int);
@@ -72,7 +72,7 @@ TEST("Result", "IsResult Result<std::pair>")
 
 TEST("Result", "IsResult Result<std::string>")
 {
-	using R = Result<std::string>;
+	using R = Result<std::string, char>;
 
 	ASSERT_NOT_CONCEPT(IsResult, R, void);
 	ASSERT_NOT_CONCEPT(IsResult, R, int);
@@ -99,7 +99,7 @@ TEST("Result", "IsResult Result<std::string>")
 
 TEST("Result", "IsResult Result<std::vector>")
 {
-	using R = Result<std::vector<int>>;
+	using R = Result<std::vector<int>, char>;
 
 	ASSERT_NOT_CONCEPT(IsResult, R, void);
 	ASSERT_NOT_CONCEPT(IsResult, R, int);
@@ -126,7 +126,7 @@ TEST("Result", "IsResult Result<std::vector>")
 
 TEST("Result", "IsResult Result<std::unique_ptr>")
 {
-	using R = Result<std::unique_ptr<int>>;
+	using R = Result<std::unique_ptr<int>, char>;
 
 	ASSERT_NOT_CONCEPT(IsResult, R, void);
 	ASSERT_NOT_CONCEPT(IsResult, R, int);
@@ -153,7 +153,7 @@ TEST("Result", "IsResult Result<std::unique_ptr>")
 
 TEST("Result", "IsResult Result<MoveOnlyWrapper>")
 {
-	using R = Result<MoveOnlyWrapper<int>>;
+	using R = Result<MoveOnlyWrapper<int>, char>;
 
 	ASSERT_NOT_CONCEPT(IsResult, R, void);
 	ASSERT_NOT_CONCEPT(IsResult, R, int);
@@ -180,7 +180,7 @@ TEST("Result", "IsResult Result<MoveOnlyWrapper>")
 
 TEST("Result", "IsResult Result<CopyOnlyWrapper>")
 {
-	using R = Result<CopyOnlyWrapper<int>>;
+	using R = Result<CopyOnlyWrapper<int>, char>;
 
 	ASSERT_NOT_CONCEPT(IsResult, R, void);
 	ASSERT_NOT_CONCEPT(IsResult, R, int);


### PR DESCRIPTION
Step 3, as outlined in #101