### PR TITLE
#146: `Epsilon` and `Anything` parsers, `eps` operator, and fix `Join` for empty spans

### DIFF
--- a/examples/json/json.cpp
+++ b/examples/json/json.cpp
@@ -21,11 +21,11 @@ constexpr auto number = []
 	constexpr auto digit = "0123456789"_any;
 
 	constexpr auto natural_number = "0"_all | join("123456789"_any >> *digit);
-	constexpr auto integer = (~"-"_all >> natural_number) % join;
+	constexpr auto integer = (("-"_all | eps) >> natural_number) % join;
 
 	constexpr auto fraction = ("."_ign >> +digit) % join;
 
-	constexpr auto exponent = (ignore("Ee"_any) >> ~"-+"_any >> +digit) % join;
+	constexpr auto exponent = (ignore("Ee"_any) >> ("-+"_any | eps) >> +digit) % join;
 
 	return (integer >> ~fraction >> ~exponent) % apply_into<number_type>;
 }();
@@ -72,14 +72,14 @@ consteval auto JsonObject::get_parser()
 {
     constexpr auto pair = (whitespace >> string >> whitespace >> ":"_ign >> JsonValue{}) % apply_into<result_type::value_type>;
     constexpr auto object = pair % delimit(","_all);
-    constexpr auto the_parser = "{"_ign >> (object | (whitespace % defaulted<result_type>)) >> "}"_ign;
+    constexpr auto the_parser = "{"_ign >> (object | whitespace) >> "}"_ign;
     return the_parser;
 }
 
 consteval auto JsonArray::get_parser()
 {
     constexpr auto values = JsonValue{} % delimit(","_all);
-    constexpr auto the_parser = "["_ign >> (values | (whitespace % defaulted<result_type>)) >> "]"_ign;
+    constexpr auto the_parser = "["_ign >> (values | whitespace) >> "]"_ign;
     return the_parser;
 }
 

--- a/include/k3/tok3n/operators.h
+++ b/include/k3/tok3n/operators.h
@@ -2,6 +2,7 @@
 
 #include <k3/tok3n/operators/basic.h>
 #include <k3/tok3n/operators/choice.h>
+#include <k3/tok3n/operators/epsilon.h>
 #include <k3/tok3n/operators/maybe.h>
 #include <k3/tok3n/operators/modifier.h>
 #include <k3/tok3n/operators/not.h>

--- a/include/k3/tok3n/operators/basic.h
+++ b/include/k3/tok3n/operators/basic.h
@@ -32,17 +32,6 @@ constexpr auto ign = Ignore<AllOf<arr>>{};
 
 
 
-template <class T>
-constexpr auto anything = NoneOf<StaticArray<T, 0>{}>{};
-
-template <class T>
-constexpr auto nothing = AnyOf<StaticArray<T, 0>{}>{};
-
-template <class T>
-constexpr auto eps = AllOf<StaticArray<T, 0>{}>{};
-
-
-
 template <StaticArray arr>
 consteval auto operator"" _any()
 {

--- a/include/k3/tok3n/operators/epsilon.h
+++ b/include/k3/tok3n/operators/epsilon.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <k3/tok3n/parsers/basic/Epsilon.h>
+#include <k3/tok3n/operators/choice.h>
+
+namespace k3::tok3n {
+
+struct EpsilonOperator
+{
+	template <class V>
+	static constexpr Epsilon<V> of = {};
+};
+
+inline constexpr EpsilonOperator eps = {};
+
+template <Parser P>
+constexpr auto operator|(P, EpsilonOperator)
+{
+	return ::k3::tok3n::operator|(P{}, Epsilon<typename P::value_type>{});
+}
+
+template <Parser P>
+constexpr auto operator|(EpsilonOperator, P) = delete;
+
+} // namespace k3::tok3n
+
+namespace k3::tok3n::operators {
+
+using ::k3::tok3n::eps;
+
+} // namespace k3::tok3n::operators

--- a/include/k3/tok3n/parsers.h
+++ b/include/k3/tok3n/parsers.h
@@ -6,6 +6,8 @@
 #include <k3/tok3n/parsers/basic/AnyOf.h>
 #include <k3/tok3n/parsers/basic/NoneOf.h>
 #include <k3/tok3n/parsers/basic/AllOf.h>
+#include <k3/tok3n/parsers/basic/Anything.h>
+#include <k3/tok3n/parsers/basic/Epsilon.h>
 
 #include <k3/tok3n/parsers/compound/Choice.h>
 #include <k3/tok3n/parsers/compound/Sequence.h>

--- a/include/k3/tok3n/parsers/basic/Anything.h
+++ b/include/k3/tok3n/parsers/basic/Anything.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <k3/tok3n/parsers/basic/_fwd.h>
+
+namespace k3::tok3n {
+
+template <class ValueType>
+struct Anything
+{
+	using value_type = ValueType;
+	
+	template <EqualityComparableWith<value_type> V>
+    using result_for = Output<V>;
+
+	static constexpr ParserFamily family = AnythingFamily;
+
+	template <InputConstructibleFor<value_type> R>
+	static constexpr auto parse(R&& r)
+	{
+		Input input{ std::forward<R>(r) };
+		using V = typename decltype(input)::value_type;
+
+        if (input.empty())
+			return Result<result_for<V>, V>{ failure, input };
+		else
+			return Result<result_for<V>, V>{ success, { input.data(), 1 }, { input.data() + 1, input.size() - 1 } };
+	}
+
+	template <InputConstructibleFor<value_type> R>
+	static constexpr auto lookahead(R&& r)
+	{
+		Input input{ std::forward<R>(r) };
+		using V = typename decltype(input)::value_type;
+
+		if (input.empty())
+			return Result<void, V>{ failure, input };
+		else
+			return Result<void, V>{ success, { input.data() + 1, input.size() - 1 } };
+	}
+};
+
+} // namespace k3::tok3n

--- a/include/k3/tok3n/parsers/basic/Epsilon.h
+++ b/include/k3/tok3n/parsers/basic/Epsilon.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <k3/tok3n/parsers/basic/_fwd.h>
+
+namespace k3::tok3n {
+
+template <class ValueType>
+struct Epsilon
+{
+	using value_type = ValueType;
+	
+	template <EqualityComparableWith<value_type> V>
+    using result_for = void;
+
+	static constexpr ParserFamily family = EpsilonFamily;
+
+	template <InputConstructibleFor<value_type> R>
+	static constexpr auto parse(R&& r)
+	{
+		Input input{ std::forward<R>(r) };
+		using V = typename decltype(input)::value_type;
+        return Result<void, V>{ success, input };
+	}
+
+	template <InputConstructibleFor<value_type> R>
+	static constexpr auto lookahead(R&& r)
+	{
+		Input input{ std::forward<R>(r) };
+		using V = typename decltype(input)::value_type;
+        return Result<void, V>{ success, input };
+	}
+};
+
+} // namespace k3::tok3n

--- a/include/k3/tok3n/parsers/basic/_fwd.h
+++ b/include/k3/tok3n/parsers/basic/_fwd.h
@@ -23,4 +23,10 @@ struct NoneOf;
 template <StaticArray arr>
 struct AllOf;
 
+template <class ValueType>
+struct Anything;
+
+template <class ValueType>
+struct Epsilon;
+
 } // namespace k3::tok3n

--- a/include/k3/tok3n/parsers/divergent/Join.h
+++ b/include/k3/tok3n/parsers/divergent/Join.h
@@ -30,7 +30,11 @@ namespace detail::executors
 		// where we check if the next string_view is adjacent in memory to the last one.
 		constexpr bool try_join(Output<ValueType> output)
 		{
-			if (!joined)
+			if (output.empty())
+			{
+				return true;
+			}
+			else if (!joined)
 			{
 				joined = output;
 				return true;

--- a/include/k3/tok3n/types/ParserFamily.h
+++ b/include/k3/tok3n/types/ParserFamily.h
@@ -9,6 +9,8 @@ enum class ParserFamily
 	AnyOf,
 	NoneOf,
 	AllOf,
+	Anything,
+	Epsilon,
 	Choice,
 	Sequence,
 	Maybe,
@@ -33,6 +35,8 @@ enum class ParserFamily
 inline constexpr ParserFamily AnyOfFamily          = ParserFamily::AnyOf;
 inline constexpr ParserFamily NoneOfFamily         = ParserFamily::NoneOf;
 inline constexpr ParserFamily AllOfFamily          = ParserFamily::AllOf;
+inline constexpr ParserFamily AnythingFamily       = ParserFamily::Anything;
+inline constexpr ParserFamily EpsilonFamily        = ParserFamily::Epsilon;
 inline constexpr ParserFamily ChoiceFamily         = ParserFamily::Choice;
 inline constexpr ParserFamily SequenceFamily       = ParserFamily::Sequence;
 inline constexpr ParserFamily MaybeFamily          = ParserFamily::Maybe;

--- a/tests/char-samples/basic.h
+++ b/tests/char-samples/basic.h
@@ -16,6 +16,9 @@ using All2 = AllOf<"ly">;      constexpr All2 all2;
 using All3 = AllOf<"test">;    constexpr All3 all3;
 using All4 = AllOf<"ab">;      constexpr All4 all4;
 
+using Eps1 = Epsilon<char>;  constexpr Eps1 eps1;
+using Ant1 = Anything<char>; constexpr Ant1 ant1;
+
 using QQ       = AllOf<"??">;  constexpr QQ       qq;
 using ABC      = AllOf<"abc">; constexpr ABC      abc;
 using Comma    = AnyOf<",">;   constexpr Comma    comma;
@@ -25,4 +28,5 @@ using SpaceDot = AnyOf<" .">;  constexpr SpaceDot spacedot;
 	(Any1) (Any2) (Any3) (Any4)        \
 	(Non1) (Non2) (Non3) (Non4) (Non5) \
 	(All1) (All2) (All3) (All4)        \
+	(Eps1) (Ant1)                      \
 	(QQ) (ABC) (Comma) (SpaceDot)

--- a/tests/char-tests/operators/basic.cpp
+++ b/tests/char-tests/operators/basic.cpp
@@ -12,7 +12,6 @@ TEST("basic operators", "UDL _any")
 	ASSERT_PARSER_VALUES_EQ(","_any, comma);
 	ASSERT_PARSER_VALUES_EQ(" ."_any, spacedot);
 	ASSERT_PARSER_VALUES_EQ(""_any, AnyOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_any, nothing<char>);
 }
 
 TEST("basic operators", "UDL _any_of")
@@ -24,7 +23,6 @@ TEST("basic operators", "UDL _any_of")
 	ASSERT_PARSER_VALUES_EQ(","_any_of, comma);
 	ASSERT_PARSER_VALUES_EQ(" ."_any_of, spacedot);
 	ASSERT_PARSER_VALUES_EQ(""_any_of, AnyOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_any_of, nothing<char>);
 }
 
 TEST("basic operators", "any<>")
@@ -36,7 +34,6 @@ TEST("basic operators", "any<>")
 	ASSERT_PARSER_VALUES_EQ(any<",">, comma);
 	ASSERT_PARSER_VALUES_EQ(any<" .">, spacedot);
 	ASSERT_PARSER_VALUES_EQ(any<"">, AnyOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(any<"">, nothing<char>);
 }
 
 TEST("basic operators", "any_of<>")
@@ -57,7 +54,6 @@ TEST("basic operators", "UDL _none")
 	ASSERT_PARSER_VALUES_EQ("cd"_none, none4);
 	ASSERT_PARSER_VALUES_EQ("z"_none, none5);
 	ASSERT_PARSER_VALUES_EQ(""_none, NoneOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_none, anything<char>);
 }
 
 TEST("basic operators", "UDL _none_of")
@@ -68,7 +64,6 @@ TEST("basic operators", "UDL _none_of")
 	ASSERT_PARSER_VALUES_EQ("cd"_none_of, none4);
 	ASSERT_PARSER_VALUES_EQ("z"_none_of, none5);
 	ASSERT_PARSER_VALUES_EQ(""_none_of, NoneOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_none_of, anything<char>);
 }
 
 TEST("basic operators", "none<>")
@@ -79,7 +74,6 @@ TEST("basic operators", "none<>")
 	ASSERT_PARSER_VALUES_EQ(none<"cd">, none4);
 	ASSERT_PARSER_VALUES_EQ(none<"z">, none5);
 	ASSERT_PARSER_VALUES_EQ(none<"">, NoneOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(none<"">, anything<char>);
 }
 
 TEST("basic operators", "none_of<>")
@@ -100,7 +94,6 @@ TEST("basic operators", "UDL _all")
 	ASSERT_PARSER_VALUES_EQ("??"_all, qq);
 	ASSERT_PARSER_VALUES_EQ("abc"_all, abc);
 	ASSERT_PARSER_VALUES_EQ(""_all, AllOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_all, eps<char>);
 }
 
 TEST("basic operators", "UDL _all_of")
@@ -112,7 +105,6 @@ TEST("basic operators", "UDL _all_of")
 	ASSERT_PARSER_VALUES_EQ("??"_all_of, qq);
 	ASSERT_PARSER_VALUES_EQ("abc"_all_of, abc);
 	ASSERT_PARSER_VALUES_EQ(""_all_of, AllOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_all_of, eps<char>);
 }
 
 TEST("basic operators", "all<>")
@@ -124,7 +116,6 @@ TEST("basic operators", "all<>")
 	ASSERT_PARSER_VALUES_EQ(all<"??">, qq);
 	ASSERT_PARSER_VALUES_EQ(all<"abc">, abc);
 	ASSERT_PARSER_VALUES_EQ(all<"">, AllOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(all<"">, eps<char>);
 }
 
 TEST("basic operators", "all_of<>")
@@ -146,7 +137,6 @@ TEST("basic operators", "UDL _ign")
 	ASSERT_PARSER_VALUES_EQ("??"_ign, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ("abc"_ign, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(""_ign, Ignore<AllOf<"">>{});
-	ASSERT_PARSER_VALUES_EQ(""_ign, Ignore<std::remove_const_t<decltype(eps<char>)>>{});
 }
 
 TEST("basic operators", "ign<>")
@@ -158,7 +148,6 @@ TEST("basic operators", "ign<>")
 	ASSERT_PARSER_VALUES_EQ(ign<"??">, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ(ign<"abc">, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(ign<"">, Ignore<AllOf<"">>{});
-	ASSERT_PARSER_VALUES_EQ(ign<"">, Ignore<std::remove_const_t<decltype(eps<char>)>>{});
 }
 
 TEST("basic operators", "Non sorted_and_uniqued")
@@ -179,8 +168,6 @@ TEST("basic operators", "Non sorted_and_uniqued")
 	ASSERT_PARSER_VALUES_EQ("A"_none, NoneOf<"A">{});
 	ASSERT_PARSER_VALUES_EQ(""_any, AnyOf<"">{});
 	ASSERT_PARSER_VALUES_EQ(""_none, NoneOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_any, nothing<char>);
-	ASSERT_PARSER_VALUES_EQ(""_none, anything<char>);
 
 	ASSERT_PARSER_VALUES_EQ("212312323321212311"_any_of, AnyOf<"123">{});
 	ASSERT_PARSER_VALUES_EQ("212312323321212311"_none_of, NoneOf<"123">{});
@@ -198,6 +185,4 @@ TEST("basic operators", "Non sorted_and_uniqued")
 	ASSERT_PARSER_VALUES_EQ("A"_none_of, NoneOf<"A">{});
 	ASSERT_PARSER_VALUES_EQ(""_any_of, AnyOf<"">{});
 	ASSERT_PARSER_VALUES_EQ(""_none_of, NoneOf<"">{});
-	ASSERT_PARSER_VALUES_EQ(""_any_of, nothing<char>);
-	ASSERT_PARSER_VALUES_EQ(""_none_of, anything<char>);
 }

--- a/tests/char-tests/operators/epsilon.cpp
+++ b/tests/char-tests/operators/epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "char-samples/char-samples.h"
+
+FIXTURE("epsilon operator");
+
+namespace {
+
+template <auto lhs, auto rhs>
+concept choice_operable = requires { lhs | rhs; };
+
+} // namespace
+
+TEST("epsilon operator", ".of<>")
+{
+	ASSERT_PARSER_VALUES_EQ(eps.of<char>, Epsilon<char>{});
+}
+
+TEST("epsilon operator", "P | eps")
+{
+	ASSERT_PARSER_VALUES_EQ(any1 | eps, (Choice<Any1, Epsilon<char>>{}));
+	ASSERT_PARSER_VALUES_EQ(any2 | eps, (Choice<Any2, Epsilon<char>>{}));
+	ASSERT_PARSER_VALUES_EQ(any3 | eps, (Choice<Any3, Epsilon<char>>{}));
+}
+
+TEST("epsilon operator", "eps | P")
+{
+	ASSERT((not choice_operable<eps, any1>), "The expression `eps | any1` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any2>), "The expression `eps | any2` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any3>), "The expression `eps | any3` compiled, but it should not");
+}

--- a/tests/char-tests/parsers/basic/Anything.cpp
+++ b/tests/char-tests/parsers/basic/Anything.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "char-samples/char-samples.h"
+
+FIXTURE("Anything");
+
+TEST("Anything", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Ant1, char);
+
+	ASSERT_IS_PARSER(Ant1, char, AnythingFamily, Output<char>);
+	ASSERT_IS_PARSER(Ant1, wchar_t, AnythingFamily, Output<wchar_t>);
+	ASSERT_IS_PARSER(Ant1, int, AnythingFamily, Output<int>);
+}
+
+TEST("Anything", "Parse")
+{
+	ASSERT_PARSE_SUCCESS(Ant1, "ab", "a", "b");
+	ASSERT_PARSE_SUCCESS(Ant1, "ba", "b", "a");
+	ASSERT_PARSE_SUCCESS(Ant1, "abc", "a", "bc");
+	ASSERT_PARSE_SUCCESS(Ant1, "Ab", "A", "b");
+	ASSERT_PARSE_SUCCESS(Ant1, "Abc", "A", "bc");
+	ASSERT_PARSE_SUCCESS(Ant1, " abc", " ", "abc");
+	ASSERT_PARSE_FAILURE(Ant1, "");
+
+	ASSERT_PARSE_SUCCESS(Ant1, L"ab", L"a", L"b");
+	ASSERT_PARSE_SUCCESS(Ant1, L"ba", L"b", L"a");
+	ASSERT_PARSE_SUCCESS(Ant1, L"abc", L"a", L"bc");
+	ASSERT_PARSE_SUCCESS(Ant1, L"Ab", L"A", L"b");
+	ASSERT_PARSE_SUCCESS(Ant1, L"Abc", L"A", L"bc");
+	ASSERT_PARSE_SUCCESS(Ant1, L" abc", L" ", L"abc");
+	ASSERT_PARSE_FAILURE(Ant1, L"");
+
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("ab"), e<int>("a"), e<int>("b"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("ba"), e<int>("b"), e<int>("a"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("abc"), e<int>("a"), e<int>("bc"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("Ab"), e<int>("A"), e<int>("b"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("Abc"), e<int>("A"), e<int>("bc"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>(" abc"), e<int>(" "), e<int>("abc"));
+	ASSERT_PARSE_FAILURE(Ant1, e<int>(""));
+}

--- a/tests/char-tests/parsers/basic/Epsilon.cpp
+++ b/tests/char-tests/parsers/basic/Epsilon.cpp
@@ -1,0 +1,67 @@
+#include "pch.h"
+#include "char-samples/char-samples.h"
+
+FIXTURE("Epsilon");
+
+TEST("Epsilon", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Eps1, char);
+
+	ASSERT_IS_PARSER(Eps1, char, EpsilonFamily, void);
+	ASSERT_IS_PARSER(Eps1, wchar_t, EpsilonFamily, void);
+	ASSERT_IS_PARSER(Eps1, int, EpsilonFamily, void);
+}
+
+TEST("Epsilon", "Parse")
+{
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "ab", "ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "ba", "ba");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "abc", "abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "Ab", "Ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "Abc", "Abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, " abc", " abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "", "");
+
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"ab", L"ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"ba", L"ba");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"abc", L"abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"Ab", L"Ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"Abc", L"Abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L" abc", L" abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"", L"");
+
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("ab"), e<int>("ab"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("ba"), e<int>("ba"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("abc"), e<int>("abc"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("Ab"), e<int>("Ab"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("Abc"), e<int>("Abc"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>(" abc"), e<int>(" abc"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>(""), e<int>(""));
+}
+
+TEST("Epsilon", "Choice<P, Epsilon>")
+{
+	auto parser = "+-"_any_of | eps;
+	using P = decltype(parser);
+
+	ASSERT_IS_PARSER(P, char, ChoiceFamily, Output<char>);
+	ASSERT_PARSE_SUCCESS(P, "+abc", "+", "abc");
+	ASSERT_PARSE_SUCCESS(P, "++abc", "+", "+abc");
+	ASSERT_PARSE_SUCCESS(P, "-abc", "-", "abc");
+	ASSERT_PARSE_SUCCESS(P, "--abc", "-", "-abc");
+	ASSERT_PARSE_SUCCESS(P, "abc", "", "abc");
+
+	ASSERT_IS_PARSER(P, wchar_t, ChoiceFamily, Output<wchar_t>);
+	ASSERT_PARSE_SUCCESS(P, L"+abc", L"+", L"abc");
+	ASSERT_PARSE_SUCCESS(P, L"++abc", L"+", L"+abc");
+	ASSERT_PARSE_SUCCESS(P, L"-abc", L"-", L"abc");
+	ASSERT_PARSE_SUCCESS(P, L"--abc", L"-", L"-abc");
+	ASSERT_PARSE_SUCCESS(P, L"abc", L"", L"abc");
+
+	ASSERT_IS_PARSER(P, int, ChoiceFamily, Output<int>);
+	ASSERT_PARSE_SUCCESS(P, e<int>("+abc"), e<int>("+"), e<int>("abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("++abc"), e<int>("+"), e<int>("+abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("-abc"), e<int>("-"), e<int>("abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("--abc"), e<int>("-"), e<int>("-abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("abc"), e<int>(""), e<int>("abc"));
+}

--- a/tests/char-tests/parsers/divergent/Join.cpp
+++ b/tests/char-tests/parsers/divergent/Join.cpp
@@ -331,3 +331,28 @@ TEST("Join", "Join<Transform>")
 	}
 }
 
+TEST("Join", "Join<Sequence<Choice<non-eps,eps>, anything>>")
+{
+	auto seq = ("+-"_any | eps) >> "abc"_all;
+	using Seq = decltype(seq);
+	ASSERT_IS_PARSER(Seq, char, SequenceFamily, std::tuple<Output<char>,Output<char>>);
+	ASSERT_IS_PARSER(Seq, wchar_t, SequenceFamily, std::tuple<Output<wchar_t>,Output<wchar_t>>);
+	ASSERT_IS_PARSER(Seq, int, SequenceFamily, std::tuple<Output<int>,Output<int>>);
+
+	using P = Join<Seq>;
+
+	ASSERT_PARSE_SUCCESS(P, "+abcd", "+abc", "d");
+	ASSERT_PARSE_SUCCESS(P, "-abcd", "-abc", "d");
+	ASSERT_PARSE_SUCCESS(P, "abcd", "abc", "d");
+	ASSERT_PARSE_FAILURE(P, " abcd");
+	
+	ASSERT_PARSE_SUCCESS(P, L"+abcd", L"+abc", L"d");
+	ASSERT_PARSE_SUCCESS(P, L"-abcd", L"-abc", L"d");
+	ASSERT_PARSE_SUCCESS(P, L"abcd", L"abc", L"d");
+	ASSERT_PARSE_FAILURE(P, L" abcd");
+	
+	ASSERT_PARSE_SUCCESS(P, e<int>("+abcd"), e<int>("+abc"), e<int>("d"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("-abcd"), e<int>("-abc"), e<int>("d"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("abcd"), e<int>("abc"), e<int>("d"));
+	ASSERT_PARSE_FAILURE(P, e<int>(" abcd"));
+}

--- a/tests/enum-samples/basic.h
+++ b/tests/enum-samples/basic.h
@@ -15,6 +15,9 @@ using All1 = AllOf<StaticArray(E::X, E::Y, E::Z)>; constexpr All1 all1;
 using All2 = AllOf<StaticArray(E::Y, E::Z)>;       constexpr All2 all2;
 using All3 = AllOf<StaticArray(E::A, E::B)>;       constexpr All3 all3;
 
+using Eps1 = Epsilon<E>;  constexpr Eps1 eps1;
+using Ant1 = Anything<E>; constexpr Ant1 ant1;
+
 using QQ       = AllOf<StaticArray(E::Question, E::Question)>; constexpr QQ       qq;
 using ABC      = AllOf<StaticArray(E::A, E::B, E::C)>;         constexpr ABC      abc;
 using Comma    = AnyOf<StaticArray(E::Com)>;                   constexpr Comma    comma;
@@ -24,4 +27,5 @@ using SpaceDot = AnyOf<StaticArray(E::Space, E::Dot)>;         constexpr SpaceDo
 	(Any1) (Any2) (Any3) (Any4)        \
 	(Non1) (Non2) (Non3) (Non4) (Non5) \
 	(All1) (All2) (All3)               \
+	(Eps1) (Ant1)                      \
 	(QQ) (ABC) (Comma) (SpaceDot)

--- a/tests/enum-tests/operators/basic.cpp
+++ b/tests/enum-tests/operators/basic.cpp
@@ -14,7 +14,6 @@ TEST("basic operators", "any<>")
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(E::Com)>, comma);
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(E::Space, E::Dot)>, spacedot);
 	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<E, 0>{})>, AnyOf<(StaticArray<E, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<E, 0>{})>, nothing<E>);
 }
 
 TEST("basic operators", "any_of<>")
@@ -35,7 +34,6 @@ TEST("basic operators", "none<>")
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(E::C, E::D)>, none4);
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(E::Z)>, none5);
 	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<E, 0>{})>, NoneOf<(StaticArray<E, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<E, 0>{})>, anything<E>);
 }
 
 TEST("basic operators", "none_of<>")
@@ -55,7 +53,6 @@ TEST("basic operators", "all<>")
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(E::Question, E::Question)>, qq);
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(E::A, E::B, E::C)>, abc);
 	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<E, 0>{})>, AllOf<(StaticArray<E, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<E, 0>{})>, eps<E>);
 }
 
 TEST("basic operators", "all_of<>")
@@ -75,7 +72,6 @@ TEST("basic operators", "ign<>")
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(E::Question, E::Question)>, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(E::A, E::B, E::C)>, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<E, 0>{})>, Ignore<AllOf<(StaticArray<E, 0>{})>>{});
-	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<E, 0>{})>, Ignore<std::remove_const_t<decltype(eps<E>)>>{});
 }
 
 TEST("basic operators", "Non sorted_and_uniqued")

--- a/tests/enum-tests/operators/epsilon.cpp
+++ b/tests/enum-tests/operators/epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "enum-samples/enum-samples.h"
+
+FIXTURE("epsilon operator");
+
+namespace {
+
+template <auto lhs, auto rhs>
+concept choice_operable = requires { lhs | rhs; };
+
+} // namespace
+
+TEST("epsilon operator", ".of<>")
+{
+	ASSERT_PARSER_VALUES_EQ(eps.of<E>, Epsilon<E>{});
+}
+
+TEST("epsilon operator", "P | eps")
+{
+	ASSERT_PARSER_VALUES_EQ(any1 | eps, (Choice<Any1, Epsilon<E>>{}));
+	ASSERT_PARSER_VALUES_EQ(any2 | eps, (Choice<Any2, Epsilon<E>>{}));
+	ASSERT_PARSER_VALUES_EQ(any3 | eps, (Choice<Any3, Epsilon<E>>{}));
+}
+
+TEST("epsilon operator", "eps | P")
+{
+	ASSERT((not choice_operable<eps, any1>), "The expression `eps | any1` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any2>), "The expression `eps | any2` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any3>), "The expression `eps | any3` compiled, but it should not");
+}

--- a/tests/enum-tests/parsers/basic/AllOf.cpp
+++ b/tests/enum-tests/parsers/basic/AllOf.cpp
@@ -25,6 +25,6 @@ TEST("AllOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AllOf, e());
 
-	ASSERT_PARSE_SUCCESS(decltype(eps<E>), e(A, B, C), e(), e(A, B, C));
-	ASSERT_PARSE_SUCCESS(decltype(eps<E>), e(), e(), e());
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<E, 0>{})>, e(A, B, C), e(), e(A, B, C));
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<E, 0>{})>, e(), e(), e());
 }

--- a/tests/enum-tests/parsers/basic/AnyOf.cpp
+++ b/tests/enum-tests/parsers/basic/AnyOf.cpp
@@ -53,6 +53,6 @@ TEST("AnyOf", "Parse")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AnyOf, L"");
 	
-	ASSERT_PARSE_FAILURE(decltype(nothing<E>), e(A, B, C));
-	ASSERT_PARSE_FAILURE(decltype(nothing<E>), e());
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<E, 0>{})>, e(A, B, C));
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<E, 0>{})>, e());
 }

--- a/tests/enum-tests/parsers/basic/Anything.cpp
+++ b/tests/enum-tests/parsers/basic/Anything.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "enum-samples/enum-samples.h"
+
+using enum E;
+
+FIXTURE("Anything");
+
+TEST("Anything", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Ant1, E);
+
+	ASSERT_IS_PARSER(Ant1, E, AnythingFamily, Output<E>);
+}
+
+TEST("Anything", "Parse")
+{
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, C, B), e(A), e(C, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, A, C), e(B), e(A, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, C, A), e(B), e(C, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, A, B), e(C), e(A, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, B, A), e(C), e(B, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Y, Z), e(X), e(Y, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Z, Y), e(X), e(Z, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, X, Z), e(Y), e(X, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, Z, X), e(Y), e(Z, X));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, X, Y), e(Z), e(X, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, Y, X), e(Z), e(Y, X));
+	ASSERT_PARSE_FAILURE(Ant1, e());
+}

--- a/tests/enum-tests/parsers/basic/Epsilon.cpp
+++ b/tests/enum-tests/parsers/basic/Epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "enum-samples/enum-samples.h"
+
+using enum E;
+
+FIXTURE("Epsilon");
+
+TEST("Epsilon", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Eps1, E);
+
+	ASSERT_IS_PARSER(Eps1, E, EpsilonFamily, void);
+}
+
+TEST("Epsilon", "Parse")
+{
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, B, C), e(A, B, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, C, B), e(A, C, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, A, C), e(B, A, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, C, A), e(B, C, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, A, B), e(C, A, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, B, A), e(C, B, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Y, Z), e(X, Y, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Z, Y), e(X, Z, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, X, Z), e(Y, X, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, Z, X), e(Y, Z, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, X, Y), e(Z, X, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, Y, X), e(Z, Y, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(), e());
+}

--- a/tests/enum-tests/parsers/basic/NoneOf.cpp
+++ b/tests/enum-tests/parsers/basic/NoneOf.cpp
@@ -53,6 +53,6 @@ TEST("NoneOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(NoneOf, L"");
 
-	ASSERT_PARSE_SUCCESS(decltype(anything<E>), e(A, B, C), e(A), e(B, C));
-	ASSERT_PARSE_FAILURE(decltype(anything<E>), e());
+	ASSERT_PARSE_SUCCESS(NoneOf<(StaticArray<E, 0>{})>, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_FAILURE(NoneOf<(StaticArray<E, 0>{})>, e());
 }

--- a/tests/int-samples/basic.h
+++ b/tests/int-samples/basic.h
@@ -15,6 +15,9 @@ using All1 = AllOf<StaticArray(E::X, E::Y, E::Z)>; constexpr All1 all1;
 using All2 = AllOf<StaticArray(E::Y, E::Z)>;       constexpr All2 all2;
 using All3 = AllOf<StaticArray(E::A, E::B)>;       constexpr All3 all3;
 
+using Eps1 = Epsilon<int>;  constexpr Eps1 eps1;
+using Ant1 = Anything<int>; constexpr Ant1 ant1;
+
 using QQ       = AllOf<StaticArray(E::Question, E::Question)>; constexpr QQ       qq;
 using ABC      = AllOf<StaticArray(E::A, E::B, E::C)>;         constexpr ABC      abc;
 using Comma    = AnyOf<StaticArray(E::Com)>;                   constexpr Comma    comma;
@@ -24,4 +27,5 @@ using SpaceDot = AnyOf<StaticArray(E::Space, E::Dot)>;         constexpr SpaceDo
 	(Any1) (Any2) (Any3) (Any4)        \
 	(Non1) (Non2) (Non3) (Non4) (Non5) \
 	(All1) (All2) (All3)               \
+	(Eps1) (Ant1)                      \
 	(QQ) (ABC) (Comma) (SpaceDot)

--- a/tests/int-tests/operators/basic.cpp
+++ b/tests/int-tests/operators/basic.cpp
@@ -14,7 +14,6 @@ TEST("basic operators", "any<>")
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(E::Com)>, comma);
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(E::Space, E::Dot)>, spacedot);
 	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<int, 0>{})>, AnyOf<(StaticArray<int, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<int, 0>{})>, nothing<int>);
 }
 
 TEST("basic operators", "any_of<>")
@@ -35,7 +34,6 @@ TEST("basic operators", "none<>")
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(E::C, E::D)>, none4);
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(E::Z)>, none5);
 	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<int, 0>{})>, NoneOf<(StaticArray<int, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<int, 0>{})>, anything<int>);
 }
 
 TEST("basic operators", "none_of<>")
@@ -55,7 +53,6 @@ TEST("basic operators", "all<>")
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(E::Question, E::Question)>, qq);
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(E::A, E::B, E::C)>, abc);
 	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<int, 0>{})>, AllOf<(StaticArray<int, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<int, 0>{})>, eps<int>);
 }
 
 TEST("basic operators", "all_of<>")
@@ -75,7 +72,6 @@ TEST("basic operators", "ign<>")
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(E::Question, E::Question)>, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(E::A, E::B, E::C)>, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<int, 0>{})>, Ignore<AllOf<(StaticArray<int, 0>{})>>{});
-	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<int, 0>{})>, Ignore<std::remove_const_t<decltype(eps<int>)>>{});
 }
 
 TEST("basic operators", "Non sorted_and_uniqued")

--- a/tests/int-tests/operators/epsilon.cpp
+++ b/tests/int-tests/operators/epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "int-samples/int-samples.h"
+
+FIXTURE("epsilon operator");
+
+namespace {
+
+template <auto lhs, auto rhs>
+concept choice_operable = requires { lhs | rhs; };
+
+} // namespace
+
+TEST("epsilon operator", ".of<>")
+{
+	ASSERT_PARSER_VALUES_EQ(eps.of<int>, Epsilon<int>{});
+}
+
+TEST("epsilon operator", "P | eps")
+{
+	ASSERT_PARSER_VALUES_EQ(any1 | eps, (Choice<Any1, Epsilon<int>>{}));
+	ASSERT_PARSER_VALUES_EQ(any2 | eps, (Choice<Any2, Epsilon<int>>{}));
+	ASSERT_PARSER_VALUES_EQ(any3 | eps, (Choice<Any3, Epsilon<int>>{}));
+}
+
+TEST("epsilon operator", "eps | P")
+{
+	ASSERT((not choice_operable<eps, any1>), "The expression `eps | any1` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any2>), "The expression `eps | any2` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any3>), "The expression `eps | any3` compiled, but it should not");
+}

--- a/tests/int-tests/parsers/basic/AllOf.cpp
+++ b/tests/int-tests/parsers/basic/AllOf.cpp
@@ -25,6 +25,6 @@ TEST("AllOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AllOf, e());
 
-	ASSERT_PARSE_SUCCESS(decltype(eps<int>), e(A, B, C), e(), e(A, B, C));
-	ASSERT_PARSE_SUCCESS(decltype(eps<int>), e(), e(), e());
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<int, 0>{})>, e(A, B, C), e(), e(A, B, C));
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<int, 0>{})>, e(), e(), e());
 }

--- a/tests/int-tests/parsers/basic/AnyOf.cpp
+++ b/tests/int-tests/parsers/basic/AnyOf.cpp
@@ -53,6 +53,6 @@ TEST("AnyOf", "Parse")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AnyOf, L"");
 	
-	ASSERT_PARSE_FAILURE(decltype(nothing<int>), e(A, B, C));
-	ASSERT_PARSE_FAILURE(decltype(nothing<int>), e());
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<int, 0>{})>, e(A, B, C));
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<int, 0>{})>, e());
 }

--- a/tests/int-tests/parsers/basic/Anything.cpp
+++ b/tests/int-tests/parsers/basic/Anything.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "int-samples/int-samples.h"
+
+using namespace E;
+
+FIXTURE("Anything");
+
+TEST("Anything", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Ant1, int);
+
+	ASSERT_IS_PARSER(Ant1, int, AnythingFamily, Output<int>);
+}
+
+TEST("Anything", "Parse")
+{
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, C, B), e(A), e(C, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, A, C), e(B), e(A, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, C, A), e(B), e(C, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, A, B), e(C), e(A, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, B, A), e(C), e(B, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Y, Z), e(X), e(Y, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Z, Y), e(X), e(Z, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, X, Z), e(Y), e(X, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, Z, X), e(Y), e(Z, X));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, X, Y), e(Z), e(X, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, Y, X), e(Z), e(Y, X));
+	ASSERT_PARSE_FAILURE(Ant1, e());
+}

--- a/tests/int-tests/parsers/basic/Epsilon.cpp
+++ b/tests/int-tests/parsers/basic/Epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "int-samples/int-samples.h"
+
+using namespace E;
+
+FIXTURE("Epsilon");
+
+TEST("Epsilon", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Eps1, int);
+
+	ASSERT_IS_PARSER(Eps1, int, EpsilonFamily, void);
+}
+
+TEST("Epsilon", "Parse")
+{
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, B, C), e(A, B, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, C, B), e(A, C, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, A, C), e(B, A, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, C, A), e(B, C, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, A, B), e(C, A, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, B, A), e(C, B, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Y, Z), e(X, Y, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Z, Y), e(X, Z, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, X, Z), e(Y, X, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, Z, X), e(Y, Z, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, X, Y), e(Z, X, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, Y, X), e(Z, Y, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(), e());
+}

--- a/tests/int-tests/parsers/basic/NoneOf.cpp
+++ b/tests/int-tests/parsers/basic/NoneOf.cpp
@@ -53,6 +53,6 @@ TEST("NoneOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(NoneOf, L"");
 
-	ASSERT_PARSE_SUCCESS(decltype(anything<int>), e(A, B, C), e(A), e(B, C));
-	ASSERT_PARSE_FAILURE(decltype(anything<int>), e());
+	ASSERT_PARSE_SUCCESS(NoneOf<(StaticArray<int, 0>{})>, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_FAILURE(NoneOf<(StaticArray<int, 0>{})>, e());
 }

--- a/tests/op_equals-samples/basic.h
+++ b/tests/op_equals-samples/basic.h
@@ -15,6 +15,9 @@ using All1 = AllOf<StaticArray(SS::X, SS::Y, SS::Z)>; constexpr All1 all1;
 using All2 = AllOf<StaticArray(SS::Y, SS::Z)>;        constexpr All2 all2;
 using All3 = AllOf<StaticArray(SS::A, SS::B)>;        constexpr All3 all3;
 
+using Eps1 = Epsilon<S>;  constexpr Eps1 eps1;
+using Ant1 = Anything<S>; constexpr Ant1 ant1;
+
 using QQ       = AllOf<StaticArray(SS::Question, SS::Question)>; constexpr QQ       qq;
 using ABC      = AllOf<StaticArray(SS::A, SS::B, SS::C)>;        constexpr ABC      abc;
 using Comma    = AnyOf<StaticArray(SS::Com)>;                    constexpr Comma    comma;
@@ -24,4 +27,5 @@ using SpaceDot = AnyOf<StaticArray(SS::Space, SS::Dot)>;         constexpr Space
 	(Any1) (Any2) (Any3) (Any4)        \
 	(Non1) (Non2) (Non3) (Non4) (Non5) \
 	(All1) (All2) (All3)               \
+	(Eps1) (Ant1)                      \
 	(QQ) (ABC) (Comma) (SpaceDot)

--- a/tests/op_equals-tests/operators/basic.cpp
+++ b/tests/op_equals-tests/operators/basic.cpp
@@ -14,7 +14,6 @@ TEST("basic operators", "any<>")
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(Com)>, comma);
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(Space, Dot)>, spacedot);
 	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<S, 0>{})>, AnyOf<(StaticArray<S, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<S, 0>{})>, nothing<S>);
 }
 
 TEST("basic operators", "any_of<>")
@@ -35,7 +34,6 @@ TEST("basic operators", "none<>")
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(B, C)>, none4);
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(Z)>, none5);
 	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<S, 0>{})>, NoneOf<(StaticArray<S, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<S, 0>{})>, anything<S>);
 }
 
 TEST("basic operators", "none_of<>")
@@ -55,7 +53,6 @@ TEST("basic operators", "all<>")
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(Question, Question)>, qq);
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(A, B, C)>, abc);
 	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<S, 0>{})>, AllOf<(StaticArray<S, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<S, 0>{})>, eps<S>);
 }
 
 TEST("basic operators", "all_of<>")
@@ -75,7 +72,6 @@ TEST("basic operators", "ign<>")
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(Question, Question)>, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(A, B, C)>, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<S, 0>{})>, Ignore<AllOf<(StaticArray<S, 0>{})>>{});
-	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<S, 0>{})>, Ignore<std::remove_const_t<decltype(eps<S>)>>{});
 }
 
 TEST("basic operators", "Non sorted_and_uniqued")

--- a/tests/op_equals-tests/operators/epsilon.cpp
+++ b/tests/op_equals-tests/operators/epsilon.cpp
@@ -1,0 +1,32 @@
+#include "pch.h"
+#include "op_equals-samples/op_equals-samples.h"
+
+using namespace SS;
+
+FIXTURE("epsilon operator");
+
+namespace {
+
+template <auto lhs, auto rhs>
+concept choice_operable = requires { lhs | rhs; };
+
+} // namespace
+
+TEST("epsilon operator", ".of<>")
+{
+	ASSERT_PARSER_VALUES_EQ(eps.of<S>, Epsilon<S>{});
+}
+
+TEST("epsilon operator", "P | eps")
+{
+	ASSERT_PARSER_VALUES_EQ(any1 | eps, (Choice<Any1, Epsilon<S>>{}));
+	ASSERT_PARSER_VALUES_EQ(any2 | eps, (Choice<Any2, Epsilon<S>>{}));
+	ASSERT_PARSER_VALUES_EQ(any3 | eps, (Choice<Any3, Epsilon<S>>{}));
+}
+
+TEST("epsilon operator", "eps | P")
+{
+	ASSERT((not choice_operable<eps, any1>), "The expression `eps | any1` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any2>), "The expression `eps | any2` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any3>), "The expression `eps | any3` compiled, but it should not");
+}

--- a/tests/op_equals-tests/parsers/basic/AllOf.cpp
+++ b/tests/op_equals-tests/parsers/basic/AllOf.cpp
@@ -25,6 +25,6 @@ TEST("AllOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AllOf, e());
 
-	ASSERT_PARSE_SUCCESS(decltype(eps<S>), e(A, B, C), e(), e(A, B, C));
-	ASSERT_PARSE_SUCCESS(decltype(eps<S>), e(), e(), e());
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<S, 0>{})>, e(A, B, C), e(), e(A, B, C));
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<S, 0>{})>, e(), e(), e());
 }

--- a/tests/op_equals-tests/parsers/basic/AnyOf.cpp
+++ b/tests/op_equals-tests/parsers/basic/AnyOf.cpp
@@ -56,6 +56,6 @@ TEST("AnyOf", "Parse")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AnyOf, L"");
 	
-	ASSERT_PARSE_FAILURE(decltype(nothing<S>), e(A, B, C));
-	ASSERT_PARSE_FAILURE(decltype(nothing<S>), e());
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<S, 0>{})>, e(A, B, C));
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<S, 0>{})>, e());
 }

--- a/tests/op_equals-tests/parsers/basic/Anything.cpp
+++ b/tests/op_equals-tests/parsers/basic/Anything.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "op_equals-samples/op_equals-samples.h"
+
+using namespace SS;
+
+FIXTURE("Anything");
+
+TEST("Anything", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Ant1, S);
+
+	ASSERT_IS_PARSER(Ant1, S, AnythingFamily, Output<S>);
+}
+
+TEST("Anything", "Parse")
+{
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, C, B), e(A), e(C, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, A, C), e(B), e(A, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, C, A), e(B), e(C, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, A, B), e(C), e(A, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, B, A), e(C), e(B, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Y, Z), e(X), e(Y, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Z, Y), e(X), e(Z, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, X, Z), e(Y), e(X, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, Z, X), e(Y), e(Z, X));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, X, Y), e(Z), e(X, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, Y, X), e(Z), e(Y, X));
+	ASSERT_PARSE_FAILURE(Ant1, e());
+}

--- a/tests/op_equals-tests/parsers/basic/Epsilon.cpp
+++ b/tests/op_equals-tests/parsers/basic/Epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "op_equals-samples/op_equals-samples.h"
+
+using namespace SS;
+
+FIXTURE("Epsilon");
+
+TEST("Epsilon", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Eps1, S);
+
+	ASSERT_IS_PARSER(Eps1, S, EpsilonFamily, void);
+}
+
+TEST("Epsilon", "Parse")
+{
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, B, C), e(A, B, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, C, B), e(A, C, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, A, C), e(B, A, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, C, A), e(B, C, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, A, B), e(C, A, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, B, A), e(C, B, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Y, Z), e(X, Y, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Z, Y), e(X, Z, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, X, Z), e(Y, X, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, Z, X), e(Y, Z, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, X, Y), e(Z, X, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, Y, X), e(Z, Y, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(), e());
+}

--- a/tests/op_equals-tests/parsers/basic/NoneOf.cpp
+++ b/tests/op_equals-tests/parsers/basic/NoneOf.cpp
@@ -56,6 +56,6 @@ TEST("NoneOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(NoneOf, L"");
 
-	ASSERT_PARSE_SUCCESS(decltype(anything<S>), e(A, B, C), e(A), e(B, C));
-	ASSERT_PARSE_FAILURE(decltype(anything<S>), e());
+	ASSERT_PARSE_SUCCESS(NoneOf<(StaticArray<S, 0>{})>, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_FAILURE(NoneOf<(StaticArray<S, 0>{})>, e());
 }

--- a/tests/structural-samples/basic.h
+++ b/tests/structural-samples/basic.h
@@ -15,6 +15,9 @@ using All1 = AllOf<StaticArray(SS::X, SS::Y, SS::Z)>; constexpr All1 all1;
 using All2 = AllOf<StaticArray(SS::Y, SS::Z)>;        constexpr All2 all2;
 using All3 = AllOf<StaticArray(SS::A, SS::B)>;        constexpr All3 all3;
 
+using Eps1 = Epsilon<S>;  constexpr Eps1 eps1;
+using Ant1 = Anything<S>; constexpr Ant1 ant1;
+
 using QQ       = AllOf<StaticArray(SS::Question, SS::Question)>; constexpr QQ       qq;
 using ABC      = AllOf<StaticArray(SS::A, SS::B, SS::C)>;        constexpr ABC      abc;
 using Comma    = AnyOf<StaticArray(SS::Com)>;                    constexpr Comma    comma;
@@ -24,4 +27,5 @@ using SpaceDot = AnyOf<StaticArray(SS::Space, SS::Dot)>;         constexpr Space
 	(Any1) (Any2) (Any3) (Any4)        \
 	(Non1) (Non2) (Non3) (Non4) (Non5) \
 	(All1) (All2) (All3)               \
+	(Eps1) (Ant1)                      \
 	(QQ) (ABC) (Comma) (SpaceDot)

--- a/tests/structural-tests/operators/basic.cpp
+++ b/tests/structural-tests/operators/basic.cpp
@@ -14,7 +14,6 @@ TEST("basic operators", "any<>")
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(Com)>, comma);
 	ASSERT_PARSER_VALUES_EQ(any<StaticArray(Space, Dot)>, spacedot);
 	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<S, 0>{})>, AnyOf<(StaticArray<S, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(any<(StaticArray<S, 0>{})>, nothing<S>);
 }
 
 TEST("basic operators", "any_of<>")
@@ -35,7 +34,6 @@ TEST("basic operators", "none<>")
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(C, D)>, none4);
 	ASSERT_PARSER_VALUES_EQ(none<StaticArray(Z)>, none5);
 	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<S, 0>{})>, NoneOf<(StaticArray<S, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(none<(StaticArray<S, 0>{})>, anything<S>);
 }
 
 TEST("basic operators", "none_of<>")
@@ -55,7 +53,6 @@ TEST("basic operators", "all<>")
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(Question, Question)>, qq);
 	ASSERT_PARSER_VALUES_EQ(all<StaticArray(A, B, C)>, abc);
 	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<S, 0>{})>, AllOf<(StaticArray<S, 0>{})>{});
-	ASSERT_PARSER_VALUES_EQ(all<(StaticArray<S, 0>{})>, eps<S>);
 }
 
 TEST("basic operators", "all_of<>")
@@ -75,7 +72,6 @@ TEST("basic operators", "ign<>")
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(Question, Question)>, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ(ign<StaticArray(A, B, C)>, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<S, 0>{})>, Ignore<AllOf<(StaticArray<S, 0>{})>>{});
-	ASSERT_PARSER_VALUES_EQ(ign<(StaticArray<S, 0>{})>, Ignore<std::remove_const_t<decltype(eps<S>)>>{});
 }
 
 TEST("basic operators", "Non sorted_and_uniqued")

--- a/tests/structural-tests/operators/epsilon.cpp
+++ b/tests/structural-tests/operators/epsilon.cpp
@@ -1,0 +1,32 @@
+#include "pch.h"
+#include "structural-samples/structural-samples.h"
+
+using namespace SS;
+
+FIXTURE("epsilon operator");
+
+namespace {
+
+template <auto lhs, auto rhs>
+concept choice_operable = requires { lhs | rhs; };
+
+} // namespace
+
+TEST("epsilon operator", ".of<>")
+{
+	ASSERT_PARSER_VALUES_EQ(eps.of<S>, Epsilon<S>{});
+}
+
+TEST("epsilon operator", "P | eps")
+{
+	ASSERT_PARSER_VALUES_EQ(any1 | eps, (Choice<Any1, Epsilon<S>>{}));
+	ASSERT_PARSER_VALUES_EQ(any2 | eps, (Choice<Any2, Epsilon<S>>{}));
+	ASSERT_PARSER_VALUES_EQ(any3 | eps, (Choice<Any3, Epsilon<S>>{}));
+}
+
+TEST("epsilon operator", "eps | P")
+{
+	ASSERT((not choice_operable<eps, any1>), "The expression `eps | any1` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any2>), "The expression `eps | any2` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any3>), "The expression `eps | any3` compiled, but it should not");
+}

--- a/tests/structural-tests/parsers/basic/AllOf.cpp
+++ b/tests/structural-tests/parsers/basic/AllOf.cpp
@@ -25,6 +25,6 @@ TEST("AllOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AllOf, e());
 
-	ASSERT_PARSE_SUCCESS(decltype(eps<S>), e(A, B, C), e(), e(A, B, C));
-	ASSERT_PARSE_SUCCESS(decltype(eps<S>), e(), e(), e());
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<S, 0>{})>, e(A, B, C), e(), e(A, B, C));
+	ASSERT_PARSE_SUCCESS(AllOf<(StaticArray<S, 0>{})>, e(), e(), e());
 }

--- a/tests/structural-tests/parsers/basic/AnyOf.cpp
+++ b/tests/structural-tests/parsers/basic/AnyOf.cpp
@@ -53,6 +53,6 @@ TEST("AnyOf", "Parse")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(AnyOf, L"");
 	
-	ASSERT_PARSE_FAILURE(decltype(nothing<S>), e(A, B, C));
-	ASSERT_PARSE_FAILURE(decltype(nothing<S>), e());
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<S, 0>{})>, e(A, B, C));
+	ASSERT_PARSE_FAILURE(AnyOf<(StaticArray<S, 0>{})>, e());
 }

--- a/tests/structural-tests/parsers/basic/Anything.cpp
+++ b/tests/structural-tests/parsers/basic/Anything.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "structural-samples/structural-samples.h"
+
+using namespace SS;
+
+FIXTURE("Anything");
+
+TEST("Anything", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Ant1, S);
+
+	ASSERT_IS_PARSER(Ant1, S, AnythingFamily, Output<S>);
+}
+
+TEST("Anything", "Parse")
+{
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(A, C, B), e(A), e(C, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, A, C), e(B), e(A, C));
+	ASSERT_PARSE_SUCCESS(Ant1, e(B, C, A), e(B), e(C, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, A, B), e(C), e(A, B));
+	ASSERT_PARSE_SUCCESS(Ant1, e(C, B, A), e(C), e(B, A));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Y, Z), e(X), e(Y, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(X, Z, Y), e(X), e(Z, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, X, Z), e(Y), e(X, Z));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Y, Z, X), e(Y), e(Z, X));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, X, Y), e(Z), e(X, Y));
+	ASSERT_PARSE_SUCCESS(Ant1, e(Z, Y, X), e(Z), e(Y, X));
+	ASSERT_PARSE_FAILURE(Ant1, e());
+}

--- a/tests/structural-tests/parsers/basic/Epsilon.cpp
+++ b/tests/structural-tests/parsers/basic/Epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "structural-samples/structural-samples.h"
+
+using namespace SS;
+
+FIXTURE("Epsilon");
+
+TEST("Epsilon", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Eps1, S);
+
+	ASSERT_IS_PARSER(Eps1, S, EpsilonFamily, void);
+}
+
+TEST("Epsilon", "Parse")
+{
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, B, C), e(A, B, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(A, C, B), e(A, C, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, A, C), e(B, A, C));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(B, C, A), e(B, C, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, A, B), e(C, A, B));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(C, B, A), e(C, B, A));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Y, Z), e(X, Y, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(X, Z, Y), e(X, Z, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, X, Z), e(Y, X, Z));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Y, Z, X), e(Y, Z, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, X, Y), e(Z, X, Y));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(Z, Y, X), e(Z, Y, X));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e(), e());
+}

--- a/tests/structural-tests/parsers/basic/NoneOf.cpp
+++ b/tests/structural-tests/parsers/basic/NoneOf.cpp
@@ -53,6 +53,6 @@ TEST("NoneOf", "Parse empty")
 {
 	ASSERT_BASIC_PARSER_CONSTRUCTIBLE(NoneOf, L"");
 
-	ASSERT_PARSE_SUCCESS(decltype(anything<S>), e(A, B, C), e(A), e(B, C));
-	ASSERT_PARSE_FAILURE(decltype(anything<S>), e());
+	ASSERT_PARSE_SUCCESS(NoneOf<(StaticArray<S, 0>{})>, e(A, B, C), e(A), e(B, C));
+	ASSERT_PARSE_FAILURE(NoneOf<(StaticArray<S, 0>{})>, e());
 }

--- a/tests/wchar_t-samples/basic.h
+++ b/tests/wchar_t-samples/basic.h
@@ -16,6 +16,9 @@ using All2 = AllOf<L"ly">;      constexpr All2 all2;
 using All3 = AllOf<L"test">;    constexpr All3 all3;
 using All4 = AllOf<L"ab">;      constexpr All4 all4;
 
+using Eps1 = Epsilon<wchar_t>;  constexpr Eps1 eps1;
+using Ant1 = Anything<wchar_t>; constexpr Ant1 ant1;
+
 using QQ       = AllOf<L"??">;  constexpr QQ       qq;
 using ABC      = AllOf<L"abc">; constexpr ABC      abc;
 using Comma    = AnyOf<L",">;   constexpr Comma    comma;
@@ -25,4 +28,5 @@ using SpaceDot = AnyOf<L" .">;  constexpr SpaceDot spacedot;
 	(Any1) (Any2) (Any3) (Any4)        \
 	(Non1) (Non2) (Non3) (Non4) (Non5) \
 	(All1) (All2) (All3) (All4)        \
+	(Eps1) (Ant1)                      \
 	(QQ) (ABC) (Comma) (SpaceDot)

--- a/tests/wchar_t-tests/operators/basic.cpp
+++ b/tests/wchar_t-tests/operators/basic.cpp
@@ -12,7 +12,6 @@ TEST("basic operators", "UDL _any")
 	ASSERT_PARSER_VALUES_EQ(L","_any, comma);
 	ASSERT_PARSER_VALUES_EQ(L" ."_any, spacedot);
 	ASSERT_PARSER_VALUES_EQ(L""_any, AnyOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_any, nothing<wchar_t>);
 }
 
 TEST("basic operators", "UDL _any_of")
@@ -24,7 +23,6 @@ TEST("basic operators", "UDL _any_of")
 	ASSERT_PARSER_VALUES_EQ(L","_any_of, comma);
 	ASSERT_PARSER_VALUES_EQ(L" ."_any_of, spacedot);
 	ASSERT_PARSER_VALUES_EQ(L""_any_of, AnyOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_any_of, nothing<wchar_t>);
 }
 
 TEST("basic operators", "any<>")
@@ -36,7 +34,6 @@ TEST("basic operators", "any<>")
 	ASSERT_PARSER_VALUES_EQ(any<L",">, comma);
 	ASSERT_PARSER_VALUES_EQ(any<L" .">, spacedot);
 	ASSERT_PARSER_VALUES_EQ(any<L"">, AnyOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(any<L"">, nothing<wchar_t>);
 }
 
 TEST("basic operators", "any_of<>")
@@ -57,7 +54,6 @@ TEST("basic operators", "UDL _none")
 	ASSERT_PARSER_VALUES_EQ(L"cd"_none, none4);
 	ASSERT_PARSER_VALUES_EQ(L"z"_none, none5);
 	ASSERT_PARSER_VALUES_EQ(L""_none, NoneOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_none, anything<wchar_t>);
 }
 
 TEST("basic operators", "UDL _none_of")
@@ -68,7 +64,6 @@ TEST("basic operators", "UDL _none_of")
 	ASSERT_PARSER_VALUES_EQ(L"cd"_none_of, none4);
 	ASSERT_PARSER_VALUES_EQ(L"z"_none_of, none5);
 	ASSERT_PARSER_VALUES_EQ(L""_none_of, NoneOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_none_of, anything<wchar_t>);
 }
 
 TEST("basic operators", "none<>")
@@ -79,7 +74,6 @@ TEST("basic operators", "none<>")
 	ASSERT_PARSER_VALUES_EQ(none<L"cd">, none4);
 	ASSERT_PARSER_VALUES_EQ(none<L"z">, none5);
 	ASSERT_PARSER_VALUES_EQ(none<L"">, NoneOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(none<L"">, anything<wchar_t>);
 }
 
 TEST("basic operators", "none_of<>")
@@ -100,7 +94,6 @@ TEST("basic operators", "UDL _all")
 	ASSERT_PARSER_VALUES_EQ(L"??"_all, qq);
 	ASSERT_PARSER_VALUES_EQ(L"abc"_all, abc);
 	ASSERT_PARSER_VALUES_EQ(L""_all, AllOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_all, eps<wchar_t>);
 }
 
 TEST("basic operators", "UDL _all_of")
@@ -112,7 +105,6 @@ TEST("basic operators", "UDL _all_of")
 	ASSERT_PARSER_VALUES_EQ(L"??"_all_of, qq);
 	ASSERT_PARSER_VALUES_EQ(L"abc"_all_of, abc);
 	ASSERT_PARSER_VALUES_EQ(L""_all_of, AllOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_all_of, eps<wchar_t>);
 }
 
 TEST("basic operators", "all<>")
@@ -124,7 +116,6 @@ TEST("basic operators", "all<>")
 	ASSERT_PARSER_VALUES_EQ(all<L"??">, qq);
 	ASSERT_PARSER_VALUES_EQ(all<L"abc">, abc);
 	ASSERT_PARSER_VALUES_EQ(all<L"">, AllOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(all<L"">, eps<wchar_t>);
 }
 
 TEST("basic operators", "all_of<>")
@@ -146,7 +137,6 @@ TEST("basic operators", "UDL _ign")
 	ASSERT_PARSER_VALUES_EQ(L"??"_ign, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ(L"abc"_ign, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(L""_ign, Ignore<AllOf<L"">>{});
-	ASSERT_PARSER_VALUES_EQ(L""_ign, Ignore<std::remove_const_t<decltype(eps<wchar_t>)>>{});
 }
 
 TEST("basic operators", "ign<>")
@@ -158,7 +148,6 @@ TEST("basic operators", "ign<>")
 	ASSERT_PARSER_VALUES_EQ(ign<L"??">, Ignore<QQ>{});
 	ASSERT_PARSER_VALUES_EQ(ign<L"abc">, Ignore<ABC>{});
 	ASSERT_PARSER_VALUES_EQ(ign<L"">, Ignore<AllOf<L"">>{});
-	ASSERT_PARSER_VALUES_EQ(ign<L"">, Ignore<std::remove_const_t<decltype(eps<wchar_t>)>>{});
 }
 
 TEST("basic operators", "Non sorted_and_uniqued")
@@ -179,8 +168,6 @@ TEST("basic operators", "Non sorted_and_uniqued")
 	ASSERT_PARSER_VALUES_EQ(L"A"_none, NoneOf<L"A">{});
 	ASSERT_PARSER_VALUES_EQ(L""_any, AnyOf<L"">{});
 	ASSERT_PARSER_VALUES_EQ(L""_none, NoneOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_any, nothing<wchar_t>);
-	ASSERT_PARSER_VALUES_EQ(L""_none, anything<wchar_t>);
 
 	ASSERT_PARSER_VALUES_EQ(L"212312323321212311"_any_of, AnyOf<L"123">{});
 	ASSERT_PARSER_VALUES_EQ(L"212312323321212311"_none_of, NoneOf<L"123">{});
@@ -198,6 +185,4 @@ TEST("basic operators", "Non sorted_and_uniqued")
 	ASSERT_PARSER_VALUES_EQ(L"A"_none_of, NoneOf<L"A">{});
 	ASSERT_PARSER_VALUES_EQ(L""_any_of, AnyOf<L"">{});
 	ASSERT_PARSER_VALUES_EQ(L""_none_of, NoneOf<L"">{});
-	ASSERT_PARSER_VALUES_EQ(L""_any_of, nothing<wchar_t>);
-	ASSERT_PARSER_VALUES_EQ(L""_none_of, anything<wchar_t>);
 }

--- a/tests/wchar_t-tests/operators/epsilon.cpp
+++ b/tests/wchar_t-tests/operators/epsilon.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "wchar_t-samples/wchar_t-samples.h"
+
+FIXTURE("epsilon operator");
+
+namespace {
+
+template <auto lhs, auto rhs>
+concept choice_operable = requires { lhs | rhs; };
+
+} // namespace
+
+TEST("epsilon operator", ".of<>")
+{
+	ASSERT_PARSER_VALUES_EQ(eps.of<wchar_t>, Epsilon<wchar_t>{});
+}
+
+TEST("epsilon operator", "P | eps")
+{
+	ASSERT_PARSER_VALUES_EQ(any1 | eps, (Choice<Any1, Epsilon<wchar_t>>{}));
+	ASSERT_PARSER_VALUES_EQ(any2 | eps, (Choice<Any2, Epsilon<wchar_t>>{}));
+	ASSERT_PARSER_VALUES_EQ(any3 | eps, (Choice<Any3, Epsilon<wchar_t>>{}));
+}
+
+TEST("epsilon operator", "eps | P")
+{
+	ASSERT((not choice_operable<eps, any1>), "The expression `eps | any1` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any2>), "The expression `eps | any2` compiled, but it should not");
+	ASSERT((not choice_operable<eps, any3>), "The expression `eps | any3` compiled, but it should not");
+}

--- a/tests/wchar_t-tests/parsers/basic/Anything.cpp
+++ b/tests/wchar_t-tests/parsers/basic/Anything.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "wchar_t-samples/wchar_t-samples.h"
+
+FIXTURE("Anything");
+
+TEST("Anything", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Ant1, wchar_t);
+
+	ASSERT_IS_PARSER(Ant1, char, AnythingFamily, Output<char>);
+	ASSERT_IS_PARSER(Ant1, wchar_t, AnythingFamily, Output<wchar_t>);
+	ASSERT_IS_PARSER(Ant1, int, AnythingFamily, Output<int>);
+}
+
+TEST("Anything", "Parse")
+{
+	ASSERT_PARSE_SUCCESS(Ant1, "ab", "a", "b");
+	ASSERT_PARSE_SUCCESS(Ant1, "ba", "b", "a");
+	ASSERT_PARSE_SUCCESS(Ant1, "abc", "a", "bc");
+	ASSERT_PARSE_SUCCESS(Ant1, "Ab", "A", "b");
+	ASSERT_PARSE_SUCCESS(Ant1, "Abc", "A", "bc");
+	ASSERT_PARSE_SUCCESS(Ant1, " abc", " ", "abc");
+	ASSERT_PARSE_FAILURE(Ant1, "");
+
+	ASSERT_PARSE_SUCCESS(Ant1, L"ab", L"a", L"b");
+	ASSERT_PARSE_SUCCESS(Ant1, L"ba", L"b", L"a");
+	ASSERT_PARSE_SUCCESS(Ant1, L"abc", L"a", L"bc");
+	ASSERT_PARSE_SUCCESS(Ant1, L"Ab", L"A", L"b");
+	ASSERT_PARSE_SUCCESS(Ant1, L"Abc", L"A", L"bc");
+	ASSERT_PARSE_SUCCESS(Ant1, L" abc", L" ", L"abc");
+	ASSERT_PARSE_FAILURE(Ant1, L"");
+
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("ab"), e<int>("a"), e<int>("b"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("ba"), e<int>("b"), e<int>("a"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("abc"), e<int>("a"), e<int>("bc"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("Ab"), e<int>("A"), e<int>("b"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>("Abc"), e<int>("A"), e<int>("bc"));
+	ASSERT_PARSE_SUCCESS(Ant1, e<int>(" abc"), e<int>(" "), e<int>("abc"));
+	ASSERT_PARSE_FAILURE(Ant1, e<int>(""));
+}

--- a/tests/wchar_t-tests/parsers/basic/Epsilon.cpp
+++ b/tests/wchar_t-tests/parsers/basic/Epsilon.cpp
@@ -1,0 +1,67 @@
+#include "pch.h"
+#include "wchar_t-samples/wchar_t-samples.h"
+
+FIXTURE("Epsilon");
+
+TEST("Epsilon", "Requirements")
+{
+	ASSERT_PARSER_VALUE_TYPE(Eps1, wchar_t);
+
+	ASSERT_IS_PARSER(Eps1, char, EpsilonFamily, void);
+	ASSERT_IS_PARSER(Eps1, wchar_t, EpsilonFamily, void);
+	ASSERT_IS_PARSER(Eps1, int, EpsilonFamily, void);
+}
+
+TEST("Epsilon", "Parse")
+{
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "ab", "ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "ba", "ba");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "abc", "abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "Ab", "Ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "Abc", "Abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, " abc", " abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, "", "");
+
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"ab", L"ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"ba", L"ba");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"abc", L"abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"Ab", L"Ab");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"Abc", L"Abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L" abc", L" abc");
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, L"", L"");
+
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("ab"), e<int>("ab"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("ba"), e<int>("ba"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("abc"), e<int>("abc"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("Ab"), e<int>("Ab"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>("Abc"), e<int>("Abc"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>(" abc"), e<int>(" abc"));
+	ASSERT_PARSE_SUCCESS_VOID(Eps1, e<int>(""), e<int>(""));
+}
+TEST("Epsilon", "Choice<P, Epsilon>")
+{
+	auto parser = L"+-"_any_of | eps;
+	using P = decltype(parser);
+
+	ASSERT_IS_PARSER(P, char, ChoiceFamily, Output<char>);
+	ASSERT_PARSE_SUCCESS(P, "+abc", "+", "abc");
+	ASSERT_PARSE_SUCCESS(P, "++abc", "+", "+abc");
+	ASSERT_PARSE_SUCCESS(P, "-abc", "-", "abc");
+	ASSERT_PARSE_SUCCESS(P, "--abc", "-", "-abc");
+	ASSERT_PARSE_SUCCESS(P, "abc", "", "abc");
+
+	ASSERT_IS_PARSER(P, wchar_t, ChoiceFamily, Output<wchar_t>);
+	ASSERT_PARSE_SUCCESS(P, L"+abc", L"+", L"abc");
+	ASSERT_PARSE_SUCCESS(P, L"++abc", L"+", L"+abc");
+	ASSERT_PARSE_SUCCESS(P, L"-abc", L"-", L"abc");
+	ASSERT_PARSE_SUCCESS(P, L"--abc", L"-", L"-abc");
+	ASSERT_PARSE_SUCCESS(P, L"abc", L"", L"abc");
+
+	ASSERT_IS_PARSER(P, int, ChoiceFamily, Output<int>);
+	ASSERT_PARSE_SUCCESS(P, e<int>("+abc"), e<int>("+"), e<int>("abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("++abc"), e<int>("+"), e<int>("+abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("-abc"), e<int>("-"), e<int>("abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("--abc"), e<int>("-"), e<int>("-abc"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("abc"), e<int>(""), e<int>("abc"));
+}
+

--- a/tests/wchar_t-tests/parsers/divergent/Join.cpp
+++ b/tests/wchar_t-tests/parsers/divergent/Join.cpp
@@ -331,3 +331,28 @@ TEST("Join", "Join<Transform>")
 	}
 }
 
+TEST("Join", "Join<Sequence<Choice<non-eps,eps>, anything>>")
+{
+	auto seq = (L"+-"_any | eps) >> L"abc"_all;
+	using Seq = decltype(seq);
+	ASSERT_IS_PARSER(Seq, char, SequenceFamily, std::tuple<Output<char>,Output<char>>);
+	ASSERT_IS_PARSER(Seq, wchar_t, SequenceFamily, std::tuple<Output<wchar_t>,Output<wchar_t>>);
+	ASSERT_IS_PARSER(Seq, int, SequenceFamily, std::tuple<Output<int>,Output<int>>);
+
+	using P = Join<Seq>;
+
+	ASSERT_PARSE_SUCCESS(P, "+abcd", "+abc", "d");
+	ASSERT_PARSE_SUCCESS(P, "-abcd", "-abc", "d");
+	ASSERT_PARSE_SUCCESS(P, "abcd", "abc", "d");
+	ASSERT_PARSE_FAILURE(P, " abcd");
+	
+	ASSERT_PARSE_SUCCESS(P, L"+abcd", L"+abc", L"d");
+	ASSERT_PARSE_SUCCESS(P, L"-abcd", L"-abc", L"d");
+	ASSERT_PARSE_SUCCESS(P, L"abcd", L"abc", L"d");
+	ASSERT_PARSE_FAILURE(P, L" abcd");
+	
+	ASSERT_PARSE_SUCCESS(P, e<int>("+abcd"), e<int>("+abc"), e<int>("d"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("-abcd"), e<int>("-abc"), e<int>("d"));
+	ASSERT_PARSE_SUCCESS(P, e<int>("abcd"), e<int>("abc"), e<int>("d"));
+	ASSERT_PARSE_FAILURE(P, e<int>(" abcd"));
+}


### PR DESCRIPTION
Closes #146 