### PR TITLE
#163: Allow `Custom` parsers to specify a result type that's different from the actual result type

### DIFF
--- a/examples/json/json.cpp
+++ b/examples/json/json.cpp
@@ -85,16 +85,14 @@ consteval auto JsonArray::get_parser()
 
 consteval auto JsonValue::get_parser()
 {
-    constexpr auto value_parser = into<result_type>
-    (
+    constexpr auto value_parser =
         string |
         number |
         JsonObject{} |
         JsonArray{} |
         "true"_all  % constant<true> |
         "false"_all % constant<false> |
-        "null"_all  % constant<nullptr>
-    );
+        "null"_all  % constant<nullptr>;
 
     return whitespace >> value_parser >> whitespace;
 }

--- a/include/k3/tok3n/types/Result.h
+++ b/include/k3/tok3n/types/Result.h
@@ -21,6 +21,14 @@ public:
 	constexpr Result(SuccessTag, T&& t, Input<U> remaining) requires std::constructible_from<T, T&&>
 		: _result(std::move(t)), _remaining(remaining) {}
 
+	template <class T2>
+	constexpr Result(const Result<T2, U>& other)
+		: _result(other._result), _remaining(other._remaining) {}
+
+	template <class T2>
+	constexpr Result(Result<T2, U>&& other)
+		: _result(std::move(other)._result), _remaining(other._remaining) {}
+
 	constexpr explicit operator bool() const noexcept { return _result.operator bool(); }
 	constexpr bool has_value() const noexcept         { return _result.has_value(); }
 
@@ -39,6 +47,10 @@ public:
 private:
 	std::optional<T> _result;
 	Input<U> _remaining;
+
+	template <class T2, class U2>
+	requires (not std::is_reference_v<T2>)
+	friend class Result;
 };
 
 template <class U>

--- a/tests/char-samples/divergent.h
+++ b/tests/char-samples/divergent.h
@@ -64,6 +64,17 @@ struct Cus1 : Custom<Cus1>
 };
 constexpr Cus1 cus1;
 
+struct Cus2 : Custom<Cus2>
+{
+	using result_type = std::size_t;
+
+	static consteval auto get_parser()
+	{
+		return _12{} % constant<(int)0>;
+	}
+};
+constexpr Cus2 cus2;
+
 #define DIVERGENT_SAMPLES              \
 	(Joi1) (Joi2) (Joi3) (Joi4) (Joi5) \
 	(Tra1) (Tra2) (Tra3) (Tra4)        \
@@ -72,4 +83,4 @@ constexpr Cus1 cus1;
 	(Api1) (Api2)                      \
 	(Con1) (Con2) (Con3) (Con4)        \
 	(Def1) (Def2)                      \
-	(Cus1)
+	(Cus1) (Cus2)

--- a/tests/char-tests/parsers/divergent/Custom.cpp
+++ b/tests/char-tests/parsers/divergent/Custom.cpp
@@ -6,15 +6,19 @@ FIXTURE("Custom");
 TEST("Custom", "Requirements")
 {
 	ASSERT_PARSER_VALUE_TYPE(Cus1, char);
+	ASSERT_PARSER_VALUE_TYPE(Cus2, char);
 
 	ASSERT_IS_PARSER(Cus1, char, CustomFamily, std::size_t);
+	ASSERT_IS_PARSER(Cus2, char, CustomFamily, std::size_t);
 
 	ASSERT_IS_PARSER(Cus1, wchar_t, CustomFamily, std::size_t);
+	ASSERT_IS_PARSER(Cus2, wchar_t, CustomFamily, std::size_t);
 
 	ASSERT_IS_PARSER(Cus1, int, CustomFamily, std::size_t);
+	ASSERT_IS_PARSER(Cus2, int, CustomFamily, std::size_t);
 }
 
-TEST("Custom", "Parse all")
+TEST("Custom", "Parse Cus1")
 {
 	ASSERT_PARSE_SUCCESS(Cus1, "abcabcabcabc??", 36, "");
 	ASSERT_PARSE_SUCCESS(Cus1, "abcabcabcabc", 12, "");
@@ -36,4 +40,25 @@ TEST("Custom", "Parse all")
 	ASSERT_PARSE_SUCCESS(Cus1, e<int>("abc"), 3, e<int>(""));
 	ASSERT_PARSE_FAILURE(Cus1, e<int>(" abc"));
 	ASSERT_PARSE_FAILURE(Cus1, e<int>(""));
+}
+
+TEST("Custom", "Parse Cus2")
+{
+	ASSERT_PARSE_SUCCESS(Cus2, "abc", (std::size_t)0, "bc");
+	ASSERT_PARSE_SUCCESS(Cus2, "bca", (std::size_t)0, "ca");
+	ASSERT_PARSE_SUCCESS(Cus2, "cab", (std::size_t)0, "ab");
+	ASSERT_PARSE_FAILURE(Cus2, "xyz");
+	ASSERT_PARSE_FAILURE(Cus2, "");
+
+	ASSERT_PARSE_SUCCESS(Cus2, L"abc", (std::size_t)0, L"bc");
+	ASSERT_PARSE_SUCCESS(Cus2, L"bca", (std::size_t)0, L"ca");
+	ASSERT_PARSE_SUCCESS(Cus2, L"cab", (std::size_t)0, L"ab");
+	ASSERT_PARSE_FAILURE(Cus2, L"xyz");
+	ASSERT_PARSE_FAILURE(Cus2, L"");
+
+	ASSERT_PARSE_SUCCESS(Cus2, e<int>("abc"), (std::size_t)0, e<int>("bc"));
+	ASSERT_PARSE_SUCCESS(Cus2, e<int>("bca"), (std::size_t)0, e<int>("ca"));
+	ASSERT_PARSE_SUCCESS(Cus2, e<int>("cab"), (std::size_t)0, e<int>("ab"));
+	ASSERT_PARSE_FAILURE(Cus2, e<int>("xyz"));
+	ASSERT_PARSE_FAILURE(Cus2, e<int>(""));
 }

--- a/tests/wchar_t-samples/divergent.h
+++ b/tests/wchar_t-samples/divergent.h
@@ -66,6 +66,17 @@ struct Cus1 : Custom<Cus1>
 };
 constexpr Cus1 cus1;
 
+struct Cus2 : Custom<Cus2, wchar_t>
+{
+	using result_type = std::size_t;
+
+	static consteval auto get_parser()
+	{
+		return _12{} % constant<(int)0>;
+	}
+};
+constexpr Cus2 cus2;
+
 #define DIVERGENT_SAMPLES              \
 	(Joi1) (Joi2) (Joi3) (Joi4) (Joi5) \
 	(Tra1) (Tra2) (Tra3) (Tra4)        \
@@ -74,4 +85,4 @@ constexpr Cus1 cus1;
 	(Api1) (Api2)                      \
 	(Con1) (Con2) (Con3) (Con4)        \
 	(Def1) (Def2)                      \
-	(Cus1)
+	(Cus1) (Cus2)

--- a/tests/wchar_t-tests/parsers/divergent/Custom.cpp
+++ b/tests/wchar_t-tests/parsers/divergent/Custom.cpp
@@ -6,15 +6,19 @@ FIXTURE("Custom");
 TEST("Custom", "Requirements")
 {
 	ASSERT_PARSER_VALUE_TYPE(Cus1, wchar_t);
+	ASSERT_PARSER_VALUE_TYPE(Cus2, wchar_t);
 
 	ASSERT_IS_PARSER(Cus1, char, CustomFamily, std::size_t);
+	ASSERT_IS_PARSER(Cus2, char, CustomFamily, std::size_t);
 
 	ASSERT_IS_PARSER(Cus1, wchar_t, CustomFamily, std::size_t);
+	ASSERT_IS_PARSER(Cus2, wchar_t, CustomFamily, std::size_t);
 
 	ASSERT_IS_PARSER(Cus1, int, CustomFamily, std::size_t);
+	ASSERT_IS_PARSER(Cus2, int, CustomFamily, std::size_t);
 }
 
-TEST("Custom", "Parse all")
+TEST("Custom", "Parse Cus1")
 {
 	ASSERT_PARSE_SUCCESS(Cus1, "abcabcabcabc??", 36, "");
 	ASSERT_PARSE_SUCCESS(Cus1, "abcabcabcabc", 12, "");
@@ -36,4 +40,25 @@ TEST("Custom", "Parse all")
 	ASSERT_PARSE_SUCCESS(Cus1, e<int>("abc"), 3, e<int>(""));
 	ASSERT_PARSE_FAILURE(Cus1, e<int>(" abc"));
 	ASSERT_PARSE_FAILURE(Cus1, e<int>(""));
+}
+
+TEST("Custom", "Parse Cus2")
+{
+	ASSERT_PARSE_SUCCESS(Cus2, "abc", (std::size_t)0, "bc");
+	ASSERT_PARSE_SUCCESS(Cus2, "bca", (std::size_t)0, "ca");
+	ASSERT_PARSE_SUCCESS(Cus2, "cab", (std::size_t)0, "ab");
+	ASSERT_PARSE_FAILURE(Cus2, "xyz");
+	ASSERT_PARSE_FAILURE(Cus2, "");
+
+	ASSERT_PARSE_SUCCESS(Cus2, L"abc", (std::size_t)0, L"bc");
+	ASSERT_PARSE_SUCCESS(Cus2, L"bca", (std::size_t)0, L"ca");
+	ASSERT_PARSE_SUCCESS(Cus2, L"cab", (std::size_t)0, L"ab");
+	ASSERT_PARSE_FAILURE(Cus2, L"xyz");
+	ASSERT_PARSE_FAILURE(Cus2, L"");
+
+	ASSERT_PARSE_SUCCESS(Cus2, e<int>("abc"), (std::size_t)0, e<int>("bc"));
+	ASSERT_PARSE_SUCCESS(Cus2, e<int>("bca"), (std::size_t)0, e<int>("ca"));
+	ASSERT_PARSE_SUCCESS(Cus2, e<int>("cab"), (std::size_t)0, e<int>("ab"));
+	ASSERT_PARSE_FAILURE(Cus2, e<int>("xyz"));
+	ASSERT_PARSE_FAILURE(Cus2, e<int>(""));
 }


### PR DESCRIPTION
Closes #163 