### PR TITLE
Allow `void`-returning sub-parsers in `Exactly`, `Maybe`, `OneOrMore`, and `ZeroOrMore`

### DIFF
--- a/include/k3/tok3n/parsers/compound/Choice.h
+++ b/include/k3/tok3n/parsers/compound/Choice.h
@@ -44,11 +44,11 @@ namespace detail
 			if constexpr (not std::same_as<void, ResultType>)
 			{
 				if constexpr (not unwrapped)
-					this->full_result.template emplace<I>(std::move(*result));
+					this->value.template emplace<I>(std::move(*result));
 				else if constexpr (std::is_move_assignable_v<ResultType>)
-					this->full_result = std::move(*result);
+					this->value = std::move(*result);
 				else
-					this->full_result = *result;
+					this->value = *result;
 			}
 			return true;
 		}
@@ -95,7 +95,7 @@ struct Choice
 		if constexpr (std::same_as<result_for<V>, void>)
 			return Result<result_for<V>, V>{ success, executor.input };
 		else
-			return Result<result_for<V>, V>{ success, std::move(executor.full_result), executor.input };
+			return Result<result_for<V>, V>{ success, std::move(executor.value), executor.input };
 	}
 
 	template <InputConstructibleFor<value_type> R>

--- a/include/k3/tok3n/parsers/compound/Sequence.h
+++ b/include/k3/tok3n/parsers/compound/Sequence.h
@@ -43,9 +43,9 @@ namespace detail
 			if constexpr (not std::same_as<void, ResultType>)
 			{
 				if constexpr (not unwrapped)
-					std::get<I>(this->full_result) = std::move(*result);
+					std::get<I>(this->value) = std::move(*result);
 				else
-					this->full_result = std::move(*result);
+					this->value = std::move(*result);
 			}
 			return true;
 		}
@@ -93,7 +93,7 @@ struct Sequence
 		if constexpr (std::same_as<result_for<V>, void>)
 			return Result<result_for<V>, V>{ success, executor.input };
 		else
-			return Result<result_for<V>, V>{ success, std::move(executor.full_result), executor.input };
+			return Result<result_for<V>, V>{ success, std::move(executor.value), executor.input };
 	}
 
 	template <InputConstructibleFor<value_type> R>

--- a/include/k3/tok3n/parsers/compound/_fwd.h
+++ b/include/k3/tok3n/parsers/compound/_fwd.h
@@ -35,7 +35,7 @@ namespace detail
 	template <class ResultType>
 	struct ExecutorData
 	{
-		ResultType full_result = {};
+		ResultType value = {};
 	};
 
 	template <>

--- a/include/k3/tok3n/parsers/repeat/Exactly.h
+++ b/include/k3/tok3n/parsers/repeat/Exactly.h
@@ -9,37 +9,35 @@ struct Exactly
 {
 	using value_type = typename P::value_type;
 
-	template <InputConstructibleFor<value_type> R, class V = InputValueType<R>>
-	static constexpr bool parsable_range = not std::same_as<typename P::template result_for<V>, void>;
-
 	template <EqualityComparableWith<value_type> V>
-	using result_for = std::array<typename P::template result_for<V>, N::value>;
+	using result_for = std::conditional_t<
+		std::same_as<void, typename P::template result_for<V>>,
+		void,
+		std::array<typename P::template result_for<V>, N::value>
+	>;
 
 	static constexpr ParserFamily family = ExactlyFamily;
 
 	template <InputConstructibleFor<value_type> R>
-	requires parsable_range<R>
 	static constexpr auto parse(R&& r)
 	{
 		Input input{ std::forward<R>(r) };
 		using V = InputValueType<R>;
 
 		const Input original_input = input;
-		result_for<V> results;
+		detail::ResultBuilder<result_for<V>> builder;
 
 		for (std::size_t i = 0; i < N::value; i++)
 		{
 			auto result = P::parse(input);
-			if (result.has_value())
-			{
-				input = result.remaining();
-				results[i] = std::move(*result);
-			}
-			else
+			if (not result.has_value())
 				return Result<result_for<V>, V>{ failure, original_input };
+
+			input = result.remaining();
+			builder.array_assign(i, std::move(result));
 		}
 
-		return Result<result_for<V>, V>{ success, std::move(results), input };
+		return std::move(builder).success(input);
 	}
 
 	template <InputConstructibleFor<value_type> R>
@@ -53,10 +51,10 @@ struct Exactly
 		for (std::size_t i = 0; i < N::value; i++)
 		{
 			auto result = P::lookahead(input);
-			if (result.has_value())
-				input = result.remaining();
-			else
+			if (not result.has_value())
 				return Result<void, V>{ failure, original_input };
+			
+			input = result.remaining();
 		}
 
 		return Result<void, V>{ success, input };

--- a/include/k3/tok3n/parsers/repeat/Maybe.h
+++ b/include/k3/tok3n/parsers/repeat/Maybe.h
@@ -8,26 +8,28 @@ struct Maybe
 {
 	using value_type = typename P::value_type;
 
-	template <InputConstructibleFor<value_type> R, class V = InputValueType<R>>
-	static constexpr bool parsable_range = not std::same_as<typename P::template result_for<V>, void>;
-
 	template <EqualityComparableWith<value_type> V>
-	using result_for = std::optional<typename P::template result_for<V>>;
+	using result_for = std::conditional_t<
+		std::same_as<void, typename P::template result_for<V>>,
+		void,
+		std::optional<typename P::template result_for<V>>
+	>;
 
 	static constexpr ParserFamily family = MaybeFamily;
 
 	template <InputConstructibleFor<value_type> R>
-	requires parsable_range<R>
 	static constexpr auto parse(R&& r)
 	{
 		Input input{ std::forward<R>(r) };
 		using V = InputValueType<R>;
 
+		detail::ResultBuilder<result_for<V>> builder;
+
 		auto result = P::parse(input);
 		if (result.has_value())
-			return Result<result_for<V>, V>{ success, std::move(*result), result.remaining() };
-		else
-			return Result<result_for<V>, V>{ success, result_for<V>{ std::nullopt }, input };
+			builder.emplace(std::move(result));
+
+		return std::move(builder).success(result.remaining());
 	}
 
 	template <InputConstructibleFor<value_type> R>

--- a/include/k3/tok3n/parsers/repeat/OneOrMore.h
+++ b/include/k3/tok3n/parsers/repeat/OneOrMore.h
@@ -8,40 +8,38 @@ struct OneOrMore
 {
 	using value_type = typename P::value_type;
 
-	template <InputConstructibleFor<value_type> R, class V = InputValueType<R>>
-	static constexpr bool parsable_range = not std::same_as<typename P::template result_for<V>, void>;
-
 	template <EqualityComparableWith<value_type> V>
-	using result_for = std::vector<typename P::template result_for<V>>;
+	using result_for = std::conditional_t<
+		std::same_as<void, typename P::template result_for<V>>,
+		void,
+		std::vector<typename P::template result_for<V>>
+	>;
 
 	static constexpr ParserFamily family = OneOrMoreFamily;
 
 	template <InputConstructibleFor<value_type> R>
-	requires parsable_range<R>
 	static constexpr auto parse(R&& r)
 	{
 		Input input{ std::forward<R>(r) };
 		using V = InputValueType<R>;
 
-		const Input original_input = input;
-		result_for<V> results;
+		detail::ResultBuilder<result_for<V>> builder;
+		bool successful = false;
 
 		while (true)
 		{
 			auto result = P::parse(input);
-			if (result.has_value())
-			{
-				input = result.remaining();
-				results.emplace_back(std::move(*result));
-			}
-			else
+			input = result.remaining();
+			successful |= result.has_value();
+			if (not result.has_value())
 				break;
+			builder.insert_back(std::move(result));
 		}
 
-		if (results.size() != 0)
-			return Result<result_for<V>, V>{ success, std::move(results), input };
+		if (successful)
+			return std::move(builder).success(input);
 		else
-			return Result<result_for<V>, V>{ failure, original_input };
+			return Result<result_for<V>, V>{ failure, input };
 	}
 
 	template <InputConstructibleFor<value_type> R>
@@ -50,15 +48,16 @@ struct OneOrMore
 		Input input{ std::forward<R>(r) };
 		using V = InputValueType<R>;
 
-		Result<void, V> result;
 		bool successful = false;
-		
-		do
+
+		while (true)
 		{
-			result = P::lookahead(input);
+			auto result = P::lookahead(input);
 			input = result.remaining();
 			successful |= result.has_value();
-		} while (result.has_value());
+			if (not result.has_value())
+				break;
+		}
 
 		if (successful)
 			return Result<void, V>{ success, input };

--- a/include/k3/tok3n/parsers/repeat/_fwd.h
+++ b/include/k3/tok3n/parsers/repeat/_fwd.h
@@ -52,6 +52,13 @@ public:
 	}
 
 	template <class U>
+	constexpr void emplace(Result<value_type, U>&& result)
+	{
+		if constexpr (not is_void)
+			this->value.emplace(*std::move(result));
+	}
+
+	template <class U>
 	constexpr Result<T, U> success(Input<U> input) &&
 	{
 		if constexpr (not is_void)

--- a/include/k3/tok3n/parsers/repeat/_fwd.h
+++ b/include/k3/tok3n/parsers/repeat/_fwd.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <k3/tok3n/types.h>
 #include <k3/tok3n/concepts.h>
+#include <k3/tok3n/parsers/compound/_fwd.h>
 #include <vector>
 
 namespace k3::tok3n {
@@ -20,5 +21,46 @@ struct ZeroOrMore;
 
 template <Parser P, ParserCompatibleWith<P> D, IsConst<bool> KeepDelimiters>
 struct Delimit;
+
+
+
+namespace detail {
+
+template <class T>
+class ResultBuilder : ExecutorData<T>
+{
+	static constexpr bool is_void = std::same_as<T, void>;
+
+	using value_type = typename decltype(
+		[]{
+			throw;
+			if constexpr (is_void)
+				return std::type_identity<void>{};
+			else
+				return std::type_identity<typename T::value_type>{};
+		}()
+	)::type;
+
+public:
+	constexpr ResultBuilder() = default;
+
+	template <class U>
+	constexpr void array_assign(std::size_t index, Result<value_type, U>&& result)
+	{
+		if constexpr (not is_void)
+			this->value[index] = *std::move(result);
+	}
+
+	template <class U>
+	constexpr Result<T, U> success(Input<U> input) &&
+	{
+		if constexpr (not is_void)
+			return { SuccessTag{}, std::move(this->value), input };
+		else
+			return { SuccessTag{}, input };
+	}
+};
+
+} // namespace detail
 
 } // namespace k3::tok3n

--- a/include/k3/tok3n/parsers/repeat/_fwd.h
+++ b/include/k3/tok3n/parsers/repeat/_fwd.h
@@ -58,6 +58,13 @@ public:
 			this->value.emplace(*std::move(result));
 	}
 
+    template <class U>
+    constexpr void insert_back(Result<value_type, U>&& result)
+    {
+        if constexpr (not is_void)
+            this->value.insert(this->value.end(), *std::move(result));
+    }
+
 	template <class U>
 	constexpr Result<T, U> success(Input<U> input) &&
 	{

--- a/tests/char-tests/parsers/repeat/Exactly.cpp
+++ b/tests/char-tests/parsers/repeat/Exactly.cpp
@@ -152,3 +152,32 @@ TEST("Exactly", "Parse Exactly<Sequence>")
 		ASSERT_PARSE_FAILURE(Exa4, e<int>());
 	}
 }
+
+TEST("Exactly", "Parse Exactly<void-parser>")
+{
+	using P = Exactly<Ignore<ABC>, Index<2>>;
+
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabcabca", "abca");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabca", "a");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabc", "");
+	ASSERT_PARSE_FAILURE(P, " abcabc");
+	ASSERT_PARSE_FAILURE(P, "abcab");
+	ASSERT_PARSE_FAILURE(P, "abc");
+	ASSERT_PARSE_FAILURE(P, "");
+
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabcabca", L"abca");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabca", L"a");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabc", L"");
+	ASSERT_PARSE_FAILURE(P, L" abcabc");
+	ASSERT_PARSE_FAILURE(P, L"abcab");
+	ASSERT_PARSE_FAILURE(P, L"abc");
+	ASSERT_PARSE_FAILURE(P, L"");
+
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabcabca"), e<int>("abca"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabca"), e<int>("a"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabc"), e<int>(""));
+	ASSERT_PARSE_FAILURE(P, e<int>(" abcabc"));
+	ASSERT_PARSE_FAILURE(P, e<int>("abcab"));
+	ASSERT_PARSE_FAILURE(P, e<int>("abc"));
+	ASSERT_PARSE_FAILURE(P, e<int>(""));
+}

--- a/tests/char-tests/parsers/repeat/Maybe.cpp
+++ b/tests/char-tests/parsers/repeat/Maybe.cpp
@@ -102,3 +102,32 @@ TEST("Maybe", "Parse Maybe<Sequence>")
 	ASSERT_PARSE_SUCCESS(May4, e<int>("aliteralaliteralcliteralbliteral"), std::nullopt, e<int>("aliteralaliteralcliteralbliteral"));
 	ASSERT_PARSE_SUCCESS(May4, e<int>(""), std::nullopt, e<int>(""));
 }
+
+TEST("Maybe", "Parse Maybe<void-parser>")
+{
+	using P = Maybe<Ignore<ABC>>;
+	
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabcabca", "abcabca");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabca", "abca");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabc", "abc");
+	ASSERT_PARSE_SUCCESS_VOID(P, " abcabc", " abcabc");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcab", "ab");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abc", "");
+	ASSERT_PARSE_SUCCESS_VOID(P, "", "");
+	
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabcabca", L"abcabca");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabca", L"abca");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabc", L"abc");
+	ASSERT_PARSE_SUCCESS_VOID(P, L" abcabc", L" abcabc");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcab", L"ab");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abc", L"");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"", L"");
+	
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabcabca"), e<int>("abcabca"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabca"), e<int>("abca"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabc"), e<int>("abc"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>(" abcabc"), e<int>(" abcabc"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcab"), e<int>("ab"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abc"), e<int>(""));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>(""), e<int>(""));
+}

--- a/tests/char-tests/parsers/repeat/OneOrMore.cpp
+++ b/tests/char-tests/parsers/repeat/OneOrMore.cpp
@@ -138,3 +138,32 @@ TEST("OneOrMore", "Parse OneOrMore<Sequence>")
 		ASSERT_PARSE_FAILURE(Oom4, e<int>(""));
 	}
 }
+
+TEST("OneOrMore", "Parse OneOrMore<void-parser>")
+{
+	using P = OneOrMore<Ignore<ABC>>;
+
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabcabca", "a");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabca", "a");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabc", "");
+	ASSERT_PARSE_FAILURE(P, " abcabc");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcab", "ab");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abc", "");
+	ASSERT_PARSE_FAILURE(P, "");
+
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabcabca", L"a");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabca", L"a");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabc", L"");
+	ASSERT_PARSE_FAILURE(P, L" abcabc");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcab", L"ab");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abc", L"");
+	ASSERT_PARSE_FAILURE(P, L"");
+
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabcabca"), e<int>("a"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabca"), e<int>("a"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabc"), e<int>(""));
+	ASSERT_PARSE_FAILURE(P, e<int>(" abcabc"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcab"), e<int>("ab"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abc"), e<int>(""));
+	ASSERT_PARSE_FAILURE(P, e<int>(""));
+}

--- a/tests/char-tests/parsers/repeat/ZeroOrMore.cpp
+++ b/tests/char-tests/parsers/repeat/ZeroOrMore.cpp
@@ -138,3 +138,32 @@ TEST("ZeroOrMore", "Parse ZeroOrMore<Sequence>")
 		ASSERT_PARSE_SUCCESS(Zom4, e<int>(""), vec_type{}, e<int>(""));
 	}
 }
+
+TEST("ZeroOrMore", "Parse ZeroOrMore<void-parser>")
+{
+	using P = ZeroOrMore<Ignore<ABC>>;
+
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabcabca", "a");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabca", "a");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcabc", "");
+	ASSERT_PARSE_SUCCESS_VOID(P, " abcabc", " abcabc");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abcab", "ab");
+	ASSERT_PARSE_SUCCESS_VOID(P, "abc", "");
+	ASSERT_PARSE_SUCCESS_VOID(P, "", "");
+
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabcabca", L"a");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabca", L"a");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcabc", L"");
+	ASSERT_PARSE_SUCCESS_VOID(P, L" abcabc", L" abcabc");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abcab", L"ab");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"abc", L"");
+	ASSERT_PARSE_SUCCESS_VOID(P, L"", L"");
+
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabcabca"), e<int>("a"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabca"), e<int>("a"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcabc"), e<int>(""));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>(" abcabc"), e<int>(" abcabc"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abcab"), e<int>("ab"));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>("abc"), e<int>(""));
+	ASSERT_PARSE_SUCCESS_VOID(P, e<int>(""), e<int>(""));
+}


### PR DESCRIPTION
Closes #184 