### PR TITLE
`join` parsers with a `std::variant` result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        clang-version: [16, 17, 18, 19]
+        # clang-version: [16, 17, 18, 19] # Fix 16
+        clang-version: [17, 18, 19]
 
     steps:
       - name: Checkout code

--- a/include/k3/tok3n/detail/apply.hpp
+++ b/include/k3/tok3n/detail/apply.hpp
@@ -1,10 +1,11 @@
-// Copyright 2024 Braden Ganetsky
+// Copyright 2024-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #ifndef K3_TOK3N_DETAIL_APPLY_HPP
 #define K3_TOK3N_DETAIL_APPLY_HPP
 
+#include <k3/tok3n/detail/type_traits.hpp>
 #include <concepts>
 #include <functional>
 #include <tuple>
@@ -16,10 +17,10 @@ namespace impl {
 
 template <class F, class Tup, std::size_t... Is>
 constexpr auto apply_invoke(F&& f, Tup&& tup, std::index_sequence<Is...>)
-noexcept(noexcept(std::invoke(std::forward<F>(f), std::get<Is>(std::forward<Tup>(tup))...)))
--> decltype(std::invoke(std::forward<F>(f), std::get<Is>(std::forward<Tup>(tup))...))
+noexcept(noexcept(std::invoke(std::forward<F>(f), adl_get<Is>(std::forward<Tup>(tup))...)))
+-> decltype(std::invoke(std::forward<F>(f), adl_get<Is>(std::forward<Tup>(tup))...))
 {
-    return std::invoke(std::forward<F>(f), std::get<Is>(std::forward<Tup>(tup))...);
+    return std::invoke(std::forward<F>(f), adl_get<Is>(std::forward<Tup>(tup))...);
 }
 
 } // namespace impl

--- a/include/k3/tok3n/detail/helpers.hpp
+++ b/include/k3/tok3n/detail/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Braden Ganetsky
+// Copyright 2023-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -120,7 +120,7 @@ struct compound_executor
 		}
 		else
 		{
-			using element_type = std::remove_cvref_t<decltype(std::get<I>(out...))>;
+			using element_type = std::remove_cvref_t<decltype(adl_get<I>(out...))>;
 			element_type element;
 			const result<void, V> res = call(P{}, input, element);
 			input = res.remaining();
@@ -129,7 +129,7 @@ struct compound_executor
 				if constexpr (type == compound_type::choice)
 					(..., out.template emplace<I>(std::move(element)));
 				else if constexpr (type == compound_type::sequence)
-					(..., (std::get<I>(out) = std::move(element)));
+					(..., (adl_get<I>(out) = std::move(element)));
 				else
 					static_assert(std::same_as<V, void>, "Unreachable"); // Always false
 			}

--- a/include/k3/tok3n/detail/parsers/basic_base.hpp
+++ b/include/k3/tok3n/detail/parsers/basic_base.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Braden Ganetsky
+// Copyright 2023-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -29,7 +29,7 @@ struct basic_parser_base
     using result_for = output_span<V>;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		result_for<input_value_t<R>> out;
 		return _impl(std::forward<R>(r), out)
@@ -38,13 +38,13 @@ struct basic_parser_base
 
 	template <input_constructible_for<value_type> R, span_like Out>
 	requires std::same_as<input_value_t<R>, typename Out::value_type>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return _impl(std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/choice.hpp
+++ b/include/k3/tok3n/detail/parsers/choice.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -32,7 +32,7 @@ public:
 	static constexpr auto parse(R&& r)
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
-			{
+		{
 			return _impl(call_parse, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{});
 		}
 		else
@@ -45,6 +45,7 @@ public:
 
 	template <input_constructible_for<value_type> R, class Out>
 	static constexpr auto parse(R&& r, Out& out)
+	requires requires { choice_parser<P, Ps...>::_impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out); }
 	{
 		return _impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out);
 	}
@@ -60,6 +61,8 @@ public:
 private:
 	template <class Call, input_constructible_for<value_type> R, std::size_t I, std::size_t... Is, class... Out>
 	requires (sizeof...(Out) <= 1)
+		and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::choice, I, P, input_value_t<R>, Out...>
+		and (... and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::choice, Is, Ps, input_value_t<R>, Out...>)
 	static constexpr result<void, input_value_t<R>> _impl(Call, R&& r, std::index_sequence<I, Is...>, Out&... out)
 	{
 		const input_span input{ std::forward<R>(r) };

--- a/include/k3/tok3n/detail/parsers/choice.hpp
+++ b/include/k3/tok3n/detail/parsers/choice.hpp
@@ -43,7 +43,7 @@ public:
 	static constexpr parser_family family = choice_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -58,14 +58,14 @@ public:
 	}
 
 	template <input_constructible_for<value_type> R, class Out>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	requires requires { choice_parser<P, Ps...>::_impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out); }
 	{
 		return _impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		constexpr auto make_minus_one = [](auto&&) { return static_cast<std::size_t>(-1); };
 		using seq = std::index_sequence<make_minus_one(P{}), make_minus_one(Ps{})...>;

--- a/include/k3/tok3n/detail/parsers/complete.hpp
+++ b/include/k3/tok3n/detail/parsers/complete.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -21,7 +21,7 @@ struct complete_parser
 	static constexpr parser_family family = complete_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -37,13 +37,13 @@ struct complete_parser
 
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_into<P, R&&, Out>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse_into, std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_lookahead, std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/delimit.hpp
+++ b/include/k3/tok3n/detail/parsers/delimit.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -93,7 +93,7 @@ public:
 	static constexpr parser_family family = delimit_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -112,7 +112,7 @@ public:
 		and parsable_into<D, R&&, result_for_d<input_value_t<R>>>
 		and pushable<adl_get_t<Out, 0>, result_for_p<input_value_t<R>>&&>
 		and pushable<adl_get_t<Out, 1>, result_for_d<input_value_t<R>>&&>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse_into, call_parse_into, std::forward<R>(r), out);
 	}
@@ -121,7 +121,7 @@ public:
 	requires std::same_as<void, result_for_p<input_value_t<R>>>
 		and parsable_into<D, R&&, result_for_d<input_value_t<R>>>
 		and pushable<Out, result_for_d<input_value_t<R>>&&>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse, call_parse_into, std::forward<R>(r), out);
 	}
@@ -130,13 +130,13 @@ public:
 	requires std::same_as<void, result_for_d<input_value_t<R>>>
 		and parsable_into<P, R&&, result_for_p<input_value_t<R>>>
 		and pushable<Out, result_for_p<input_value_t<R>>&&>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse_into, call_parse, std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_lookahead, call_lookahead, std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/epsilon.hpp
+++ b/include/k3/tok3n/detail/parsers/epsilon.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Braden Ganetsky
+// Copyright 2024-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -21,7 +21,7 @@ struct epsilon_parser
 	static constexpr parser_family family = epsilon_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		const input_span input{ std::forward<R>(r) };
 		using V = input_value_t<R>;
@@ -29,7 +29,7 @@ struct epsilon_parser
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		const input_span input{ std::forward<R>(r) };
 		using V = input_value_t<R>;

--- a/include/k3/tok3n/detail/parsers/exactly.hpp
+++ b/include/k3/tok3n/detail/parsers/exactly.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -28,7 +28,7 @@ struct exactly_parser
 	static constexpr parser_family family = exactly_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -46,13 +46,13 @@ struct exactly_parser
 	requires parsable_into<P, R&&, std::remove_cvref_t<decltype(index(std::declval<Out&>(), std::size_t{}))>>
 		and std::is_default_constructible_v<Out>
 		and std::is_move_assignable_v<Out>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse_into, std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_lookahead, std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/filter.hpp
+++ b/include/k3/tok3n/detail/parsers/filter.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Braden Ganetsky
+// Copyright 2024-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -31,7 +31,7 @@ struct filter_parser
 	static constexpr parser_family family = filter_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -48,13 +48,13 @@ struct filter_parser
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_into<P, R&&, Out>
 		and std::convertible_to<std::invoke_result_t<typename FunctionValue::value_type, const Out&>, bool>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _parse_impl(std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return P::lookahead(std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/ignore.hpp
+++ b/include/k3/tok3n/detail/parsers/ignore.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -21,13 +21,13 @@ struct ignore_parser
 	static constexpr parser_family family = ignore_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		return P::lookahead(std::forward<R>(r));
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return P::lookahead(std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/join.hpp
+++ b/include/k3/tok3n/detail/parsers/join.hpp
@@ -149,7 +149,7 @@ struct join_parser_base<join_parser<P>>
 
 	template <input_constructible_for<value_type> R>
 	requires requires (R&& r, result_for<input_value_t<R>>& out) { join_parser<P>::_parse_impl(std::forward<R>(r), out); }
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		result_for<input_value_t<R>> out;
 		return join_parser<P>::_parse_impl(std::forward<R>(r), out)
@@ -159,13 +159,13 @@ struct join_parser_base<join_parser<P>>
 	template <input_constructible_for<value_type> R, span_like Out>
 	requires requires (R&& r, Out& out) { join_parser<P>::_parse_impl(std::forward<R>(r), out); }
 		and std::same_as<input_value_t<R>, typename Out::value_type>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return join_parser<P>::_parse_impl(std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return P::lookahead(std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/map.hpp
+++ b/include/k3/tok3n/detail/parsers/map.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -26,7 +26,7 @@ struct map_parser
 	static constexpr parser_family family = map_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -43,7 +43,7 @@ struct map_parser
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_void<P, R&&>
 		and invoke_assignable_to<Out&, typename FunctionValue::value_type>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _parse_impl(std::forward<R>(r), out);
 	}
@@ -51,13 +51,13 @@ struct map_parser
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_into<P, R&&, typename P::template result_for<input_value_t<R>>>
 		and invoke_assignable_to<Out&, typename FunctionValue::value_type, typename P::template result_for<input_value_t<R>>&&>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _parse_impl(std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return P::lookahead(std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/maybe.hpp
+++ b/include/k3/tok3n/detail/parsers/maybe.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -27,7 +27,7 @@ struct maybe_parser
 	static constexpr parser_family family = maybe_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -44,13 +44,13 @@ struct maybe_parser
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_into<P, R&&, typename P::template result_for<input_value_t<R>>>
 		and std::is_assignable_v<Out&, typename P::template result_for<input_value_t<R>>&&>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse_into, std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_lookahead, std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/named.hpp
+++ b/include/k3/tok3n/detail/parsers/named.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Braden Ganetsky
+// Copyright 2024-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -21,7 +21,7 @@ struct named_parser
 	static constexpr parser_family family = named_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -37,13 +37,13 @@ struct named_parser
 
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_into<P, R&&, Out>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return P::parse(std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return P::lookahead(std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/one_or_more.hpp
+++ b/include/k3/tok3n/detail/parsers/one_or_more.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -27,7 +27,7 @@ struct one_or_more_parser
 	static constexpr parser_family family = one_or_more_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -44,13 +44,13 @@ struct one_or_more_parser
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_into<P, R&&, typename P::template result_for<input_value_t<R>>>
 		and pushable<Out, typename P::template result_for<input_value_t<R>>&&>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse_into, std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_lookahead, std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/parsers/sequence.hpp
+++ b/include/k3/tok3n/detail/parsers/sequence.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -32,7 +32,7 @@ public:
 	static constexpr auto parse(R&& r)
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
-			{
+		{
 			return _impl(call_parse, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{});
 		}
 		else
@@ -45,6 +45,7 @@ public:
 
 	template <input_constructible_for<value_type> R, class Out>
 	static constexpr auto parse(R&& r, Out& out)
+	requires requires { sequence_parser<P, Ps...>::_impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out); }
 	{
 		return _impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out);
 	}
@@ -60,6 +61,8 @@ public:
 private:
 	template <class Call, input_constructible_for<value_type> R, std::size_t I, std::size_t... Is, class... Out>
 	requires (sizeof...(Out) <= 1)
+		and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::sequence, I, P, input_value_t<R>, Out...>
+		and (... and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::sequence, Is, Ps, input_value_t<R>, Out...>)
 	static constexpr result<void, input_value_t<R>> _impl(Call, R&& r, std::index_sequence<I, Is...>, Out&... out)
 	{
 		const input_span input{ std::forward<R>(r) };

--- a/include/k3/tok3n/detail/parsers/sequence.hpp
+++ b/include/k3/tok3n/detail/parsers/sequence.hpp
@@ -22,6 +22,20 @@ private:
 	template <equality_comparable_with<value_type> V>
 	using _trait = compound_trait<filter_out_void, std::tuple, V, P, Ps...>;
 
+	template <class Call, input_constructible_for<value_type> R, std::size_t I, std::size_t... Is, class... Out>
+	requires (sizeof...(Out) <= 1)
+		and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::sequence, I, P, input_value_t<R>, Out...>
+		and (... and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::sequence, Is, Ps, input_value_t<R>, Out...>)
+	static constexpr result<void, input_value_t<R>> _impl(Call, R&& r, std::index_sequence<I, Is...>, Out&... out)
+	{
+		const input_span input{ std::forward<R>(r) };
+		using V = input_value_t<R>;
+
+		auto executor = compound_executor<V, _trait<V>::unwrapped, Call, compound_type::sequence>{ input };
+		const bool successful = (executor.template exec<I>(P{}, out...) and ... and executor.template exec<Is>(Ps{}, out...));
+		return result<void, V>{ successful, successful ? executor.input : input };
+	}
+
 public:
 	template <equality_comparable_with<value_type> V>
 	using result_for = typename _trait<V>::result_for;
@@ -56,21 +70,6 @@ public:
 		constexpr auto make_minus_one = [](auto&&) { return static_cast<std::size_t>(-1); };
 		using seq = std::index_sequence<make_minus_one(P{}), make_minus_one(Ps{})...>;
 		return _impl(call_lookahead, std::forward<R>(r), seq{});
-	}
-
-private:
-	template <class Call, input_constructible_for<value_type> R, std::size_t I, std::size_t... Is, class... Out>
-	requires (sizeof...(Out) <= 1)
-		and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::sequence, I, P, input_value_t<R>, Out...>
-		and (... and impl::compound_executable<_trait<input_value_t<R>>::unwrapped, compound_type::sequence, Is, Ps, input_value_t<R>, Out...>)
-	static constexpr result<void, input_value_t<R>> _impl(Call, R&& r, std::index_sequence<I, Is...>, Out&... out)
-	{
-		const input_span input{ std::forward<R>(r) };
-		using V = input_value_t<R>;
-
-		auto executor = compound_executor<V, _trait<V>::unwrapped, Call, compound_type::sequence>{ input };
-		const bool successful = (executor.template exec<I>(P{}, out...) and ... and executor.template exec<Is>(Ps{}, out...));
-		return result<void, V>{ successful, successful ? executor.input : input };
 	}
 };
 

--- a/include/k3/tok3n/detail/parsers/sequence.hpp
+++ b/include/k3/tok3n/detail/parsers/sequence.hpp
@@ -43,7 +43,7 @@ public:
 	static constexpr parser_family family = sequence_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -58,14 +58,14 @@ public:
 	}
 
 	template <input_constructible_for<value_type> R, class Out>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	requires requires { sequence_parser<P, Ps...>::_impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out); }
 	{
 		return _impl(call_parse_into, std::forward<R>(r), typename _trait<input_value_t<R>>::sequence{}, out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		constexpr auto make_minus_one = [](auto&&) { return static_cast<std::size_t>(-1); };
 		using seq = std::index_sequence<make_minus_one(P{}), make_minus_one(Ps{})...>;

--- a/include/k3/tok3n/detail/parsers/zero_or_more.hpp
+++ b/include/k3/tok3n/detail/parsers/zero_or_more.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Braden Ganetsky
+// Copyright 2022-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -27,7 +27,7 @@ struct zero_or_more_parser
 	static constexpr parser_family family = zero_or_more_family;
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto parse(R&& r)
+	static constexpr auto parse(R&& r) -> result<result_for<input_value_t<R>>, input_value_t<R>>
 	{
 		if constexpr (std::same_as<void, result_for<input_value_t<R>>>)
 		{
@@ -44,13 +44,13 @@ struct zero_or_more_parser
 	template <input_constructible_for<value_type> R, class Out>
 	requires parsable_into<P, R&&, typename P::template result_for<input_value_t<R>>>
 		and pushable<Out, typename P::template result_for<input_value_t<R>>&&>
-	static constexpr auto parse(R&& r, Out& out)
+	static constexpr auto parse(R&& r, Out& out) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_parse_into, std::forward<R>(r), out);
 	}
 
 	template <input_constructible_for<value_type> R>
-	static constexpr auto lookahead(R&& r)
+	static constexpr auto lookahead(R&& r) -> result<void, input_value_t<R>>
 	{
 		return _impl(call_lookahead, std::forward<R>(r));
 	}

--- a/include/k3/tok3n/detail/type_traits.hpp
+++ b/include/k3/tok3n/detail/type_traits.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Braden Ganetsky
+// Copyright 2023-2025 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -161,6 +161,15 @@ constexpr decltype(auto) adl_get(T&& t)
 {
 	using std::get;
 	return get<I>(std::forward<T>(t));
+}
+
+template <class T, class U, std::size_t I>
+concept emplaceable = requires (T& t, U u) { t.template emplace<I>(static_cast<U>(u)); };
+
+template <std::size_t I, class U, emplaceable<U, I> T>
+constexpr decltype(auto) emplace(T& t, U&& u)
+{
+	return t.template emplace<I>(std::forward<U>(u));
 }
 
 template <class T, std::size_t I>


### PR DESCRIPTION
Closes #201 

This PR includes other required changes, like properly constraining the choice and sequence parsers.